### PR TITLE
Add -host-ip argument for cases when the hostname resolves to docker0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,19 @@ Registrator pairs well with [ambassadord](https://github.com/progrium/ambassador
 
 ## Starting Registrator
 
-Registrator assumes the default Docker socket at `file:///var/run/docker.sock` or you can override it with `DOCKER_HOST`. The only argument is a registry URI, which specifies and configures the registry backend to use.
+Registrator assumes the default Docker socket at `file:///var/run/docker.sock` or you can override it with `DOCKER_HOST`. The only  mandatory argument is a registry URI, which specifies and configures the registry backend to use.
 
 	$ registrator <registry-uri>
 
-However, it was designed to just be run as a container. You must pass the Docker socket file as a mount to `/tmp/docker.sock`, and it's a good idea to set the hostname to the machine host:
+By default, when registering a service, registrator will assign the service address by attempting to resolve the current hostname. If you would like to force the service address to be a specific address, you can specify the -ip argument. This is useful when running registrator inside a container, and the host address resolves to the docker0 interface.
+
+	$ registrator -ip=x.x.x.x <registry-uri>
+
+Registrator was designed to just be run as a container. You must pass the Docker socket file as a mount to `/tmp/docker.sock`, and it's a good idea to set the hostname to the machine host:
 
 	$ docker run -d \
 		-v /var/run/docker.sock:/tmp/docker.sock \
-		-h $HOSTNAME progrium/registrator <registry-uri>
+		-h $HOSTNAME progrium/registrator -ip=x.x.x.x <registry-uri>
 
 ### Registry URIs
 

--- a/bridge.go
+++ b/bridge.go
@@ -46,6 +46,10 @@ func NewService(container *dockerapi.Container, port PublishedPort, isgroup bool
 		}
 	}
 
+	if *hostIp != "" {
+		port.HostIP = *hostIp
+	}
+
 	metadata := serviceMetaData(container.Config.Env, port.ExposedPort)
 
 	service := new(Service)

--- a/registrator.go
+++ b/registrator.go
@@ -10,6 +10,8 @@ import (
 	dockerapi "github.com/fsouza/go-dockerclient"
 )
 
+var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
+
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
 		return env
@@ -53,7 +55,12 @@ func NewServiceRegistry(uri *url.URL) ServiceRegistry {
 }
 
 func main() {
+
 	flag.Parse()
+
+	if *hostIp != "" {
+		log.Println("registrator: Forcing host IP to", *hostIp)
+	}
 
 	docker, err := dockerapi.NewClient(getopt("DOCKER_HOST", "unix:///var/run/docker.sock"))
 	assert(err)


### PR DESCRIPTION
The containerized version of registrator sets the IP address of the service as the hostname, which resolves to the docker0 address, and not the externally visible address. Added -host-ip to allow that to be fixed. 

Also added a log message to indicate the backend + uri, since I kept setting it wrong and it would hang because the uri was wrong. :) 
