### PR TITLE
Consul KV addition fail with a leading / on Key

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -42,7 +42,7 @@ func (r *ConsulRegistry) registerWithCatalog(service *Service) error {
 }
 
 func (r *ConsulRegistry) registerWithKV(service *Service) error {
-	path := r.path + "/" + service.Name + "/" + service.ID
+	path := r.path[1:] + "/" + service.Name + "/" + service.ID
 	port := strconv.Itoa(service.Port)
 	addr := net.JoinHostPort(service.IP, port)
 	_, err := r.client.KV().Put(&consulapi.KVPair{Key: path, Value: []byte(addr)}, nil)


### PR DESCRIPTION
I had to drop the first character in the path in order to get consul to accept KV from registrator. Disclaimer: this is the first I've touched go code (over and above 'Hello World'), so it might not be very idiomatic.
