### PR TITLE
Use etcd Set instead of Create to get around HTTP 412 Precondition Fai...

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -25,7 +25,7 @@ func (r *EtcdRegistry) Register(service *Service) error {
 	path := r.path + "/" + service.Name + "/" + service.ID
 	port := strconv.Itoa(service.Port)
 	addr := net.JoinHostPort(service.IP, port)
-	_, err := r.client.Create(path, addr, 0)
+	_, err := r.client.Set(path, addr, uint64(0))
 	return err
 }
 


### PR DESCRIPTION
The Create call fails with "HTTP 412 Precondition Failed" - Set  works - it either create a  new or updates an existing entry.
