### PR TITLE
Create -tag, which creates tags that apply to all services

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -35,6 +35,16 @@ type Service struct {
 	pp PublishedPort
 }
 
+func CombineTags(tagParts ...string) []string {
+	tags := make([]string, 0)
+	for _, element := range tagParts {
+		if element != "" {
+			tags = append(tags, strings.Split(element, ",")...)
+		}
+	}
+	return tags
+}
+
 func NewService(port PublishedPort, isgroup bool) *Service {
 	container := port.Container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
@@ -80,14 +90,11 @@ func NewService(port PublishedPort, isgroup bool) *Service {
 	}
 	service.Port = p
 
-	service.Tags = make([]string, 0)
-	tags := mapdefault(metadata, "tags", "")
-	if tags != "" {
-		service.Tags = append(service.Tags, strings.Split(tags, ",")...)
-	}
 	if port.PortType == "udp" {
-		service.Tags = append(service.Tags, "udp")
+		service.Tags = CombineTags(mapdefault(metadata, "tags", ""), *forceTag, "udp")
 		service.ID = service.ID + ":udp"
+	} else {
+		service.Tags = CombineTags(mapdefault(metadata, "tags", ""), *forceTag)
 	}
 
 	id := mapdefault(metadata, "id", "")

--- a/registrator.go
+++ b/registrator.go
@@ -16,6 +16,7 @@ var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
+var forceTags = flag.String("tags", "", "Append tags for all registered services")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {


### PR DESCRIPTION
This pull request adds the `-tag` command line flag, which causes the specified tags to be applied to all registered services 
The default value of for this is 'registrator', which will tag all services with 'registrator'.
