### PR TITLE
Run initial `bridge.Add` in a goroutine

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -79,7 +79,7 @@ func main() {
 	containers, err := docker.ListContainers(dockerapi.ListContainersOptions{})
 	assert(err)
 	for _, listing := range containers {
-		bridge.Add(listing.ID)
+		go bridge.Add(listing.ID)
 	}
 
 	events := make(chan *dockerapi.APIEvents)


### PR DESCRIPTION
The following just happened to me:

* A service was set to be registered at startup.
* `bridge.Add()` was called at the line in this patch
* However, there was a problem with registration, so initialization was stalled in [backed off `retry`](https://github.com/progrium/registrator/blob/51b069973a619a1a2eaa014c3665911837346ca9/bridge.go#L157) in the main goroutine .
* With init stalled, the Docker api channel was never opened, and it looked like registrator was having problems listening to Docker events.

So maybe just run the initial registrations in a goroutine too?