### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go:
+- 1.3
+env:
+- "PATH=/home/travis/gopath/bin:$PATH"
+before_install:
+- go get github.com/tools/godep
+script: godep go build


### PR DESCRIPTION
This could help, to spot a build failure.

Travis is also able to upload artifacts using github api [releases](http://docs.travis-ci.com/user/deployment/releases/). But
unfortunately travis can't cross compile by default. I see 2 ways:

- use [gox](https://github.com/mitchellh/gox) or similar
- build only for linux. registrator normally is used in a docker container, so maybe the darwin build isn't needed.