### PR TITLE
SkyDNS2: service.ID is not valid DNS component

### DIFF
--- a/skydns2.go
+++ b/skydns2.go
@@ -39,7 +39,7 @@ func (r *Skydns2Registry) Refresh(service *Service) error {
 }
 
 func (r *Skydns2Registry) servicePath(service *Service) string {
-	return r.path + "/" + service.Name + "/" + service.ID
+	return r.path + "/" + service.Name + "/" + strings.Replace(service.ID, ":", "-", -1)
 }
 
 func domainPath(domain string) string {


### PR DESCRIPTION
SkyDNS2 uses etcd paths to construct DNS names. Currently SkyDNS2 backend will use Service.ID in the path and this result in malformed DNS names. SkyDNS2 is fine registering them. However, it is hard to use them from DNS clients.

Here is an example of fully qualified DNS name for a docker container:
````
    d71d2242c6b1:mesos-da107fc7-8d16-4da3-bfb9-ee36680e8b7f:80.hello-world.igor.dev.
````
Clients will choke on ":" part.

With proposed change full DNS name will look like:
````
    d71d2242c6b1-mesos-da107fc7-8d16-4da3-bfb9-ee36680e8b7f-80.hello-world.igor.dev.
````

Full dig output:

````
[ec2-user@ip-10-214-18-116 ~]$ dig @10.221.12.10 SRV hello-world.igor.dev

; <<>> DiG 9.8.2rc1-RedHat-9.8.2-0.23.rc1.32.amzn1 <<>> @10.221.12.10 SRV hello-world.igor.dev
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 2817
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 2

;; QUESTION SECTION:
;hello-world.igor.dev.		IN	SRV

;; ANSWER SECTION:
hello-world.igor.dev.	26	IN	SRV	10 50 31000 67bb0b671b66:mesos-b16baaab-5823-4ac0-95c3-5e38711fb3fb:80.hello-world.igor.dev.
hello-world.igor.dev.	26	IN	SRV	10 50 31000 d71d2242c6b1:mesos-da107fc7-8d16-4da3-bfb9-ee36680e8b7f:80.hello-world.igor.dev.

;; ADDITIONAL SECTION:
67bb0b671b66:mesos-b16baaab-5823-4ac0-95c3-5e38711fb3fb:80.hello-world.igor.dev. 29 IN A 10.214.2.78
d71d2242c6b1:mesos-da107fc7-8d16-4da3-bfb9-ee36680e8b7f:80.hello-world.igor.dev. 26 IN A 10.221.11.49
````