### PR TITLE
Change .HostIp to .HostIP to match change in go-dockerclient.

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -154,7 +154,7 @@ func (b *RegistryBridge) Add(containerId string) {
 		var hp, hip string
 		if len(published) > 0 {
 			hp = published[0].HostPort
-			hip = published[0].HostIp
+			hip = published[0].HostIP
 		}
 		p := strings.Split(string(port), "/")
 		ports = append(ports, PublishedPort{


### PR DESCRIPTION
github.com/fsouza/go-dockerclient changed the struct field name for docker.PortBinding.HostIp to .HostIP in its master. This changes registrator's reference to it to match, allowing builds to succeed.
