### PR TITLE
fixed small bug which keeps project from building

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -154,7 +154,7 @@ func (b *RegistryBridge) Add(containerId string) {
 		var hp, hip string
 		if len(published) > 0 {
 			hp = published[0].HostPort
-			hip = published[0].HostIP
+			hip = published[0].HostIp
 		}
 		p := strings.Split(string(port), "/")
 		ports = append(ports, PublishedPort{


### PR DESCRIPTION
./bridge.go:157: published[0].HostIP undefined (type docker.PortBinding has no field or method HostIP)
godep: go exit status 2
make: *** [release] Error 1

just switched HostIP to HostIp to work with latested go-dockerclient version