### PR TITLE
Read published addresses from SERVICES_EXT env var

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -169,6 +169,38 @@ func (b *RegistryBridge) Add(containerId string) {
 		// }
 	}
 
+	for _, kv := range container.Config.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		if parts[0] != "SERVICES_EXT" {
+			continue
+		}
+		for _, addr := range strings.Split(parts[1], ",") {
+			port := addr
+			hip := "0.0.0.0"
+			parts := strings.SplitN(addr, ":", 2)
+			if len(parts) == 2 {
+				addr = parts[0]
+				port = parts[1]
+			}
+
+			portType := "tcp"
+			p := strings.SplitN(string(port), "/", 2)
+			if len(p) == 2 {
+				port = p[0]
+				portType = p[1]
+			}
+			ports = append(ports, PublishedPort{
+				HostPort:    port,
+				HostIP:      hip,
+				HostName:    container.Config.Hostname,
+				ExposedPort: port,
+				ExposedIP:   container.NetworkSettings.IPAddress,
+				PortType:    portType,
+				Container:   container,
+			})
+		}
+	}
+
 	for _, port := range ports {
 		if *internal != true && port.HostPort == "" {
 			log.Println("registrator: ignored", container.ID[:12], "port", port.ExposedPort, "not published on host")


### PR DESCRIPTION
Additionally to registering all services exposed by Docker, registrator
will now also register addresses specified in SERVICES_EXT.

This is useful if you're using host networking and the container manage
it's addresses on it's own. This closes #77.