### PR TITLE
Improved Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 release
 registrator
+.build/
+stage/

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deps: $(GOPATH)/.deps_installed
 update-deps: $(GOPATH)/.deps_installed
 	@echo "Retrieving dependencies"
 	@$(GODEP) restore
-	@cd $(GOPATH)/src/$(PKG_PATH) && ./update-deps.sh
+	@cd $(GOPATH)/src/$(PKG_PATH) && ./update-deps.sh $(PKG_PATH)
 
 ## build the binary for local use
 stage/$(NAME): $(GODEP) $(SOURCES) | deps stage

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ update-deps: $(GOPATH)/.deps_installed
 	@cd $(GOPATH)/src/$(PKG_PATH) && ./update-deps.sh
 
 ## build the binary for local use
-stage/$(NAME): $(GODEP) deps $(SOURCES) | stage
+stage/$(NAME): $(GODEP) $(SOURCES) | deps stage
 	$(GODEP) go build -o $@ -ldflags '-X main.version $(VERSION)' -v .
 
 ## shortcut

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ $(GODEP): | $(GOPATH)
 	@go get github.com/tools/godep
 
 ## retrieve/restore dependencies with godep
+## hm, turns out that's not necessary!
 $(GOPATH)/.deps_installed: $(GODEP) Godeps/Godeps.json | $(GOPATH)
-	@echo "Retrieving dependencies"
-	@$(GODEP) restore
+#	@echo "Retrieving dependencies"
+#	@$(GODEP) restore
 	
 #	ensure this project can be imported
 	@mkdir -p $(shell dirname $(GOPATH)/src/$(PKG_PATH))
@@ -47,6 +48,8 @@ deps: $(GOPATH)/.deps_installed
 
 ## update dependencies to their latest versions and save *all* dependencies
 update-deps: $(GOPATH)/.deps_installed
+	@echo "Retrieving dependencies"
+	@$(GODEP) restore
 	@cd $(GOPATH)/src/$(PKG_PATH) && ./update-deps.sh
 
 ## build the binary for local use

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,74 @@
 NAME=registrator
-HARDWARE=$(shell uname -m)
-VERSION=0.4.0
 
-build:
+## the go-get'able path
+PKG_PATH=github.com/progrium/$(NAME)
+
+## version, taken from Git tag (like v1.0.0) or hash
+VERSION:=$(shell git describe --always --dirty | sed -e 's/^v//g' )
+
+## all non-test source files
+SOURCES:=$(shell go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{.}} {{end}}' ./... | sed -e "s@$(PWD)/@@g" )
+
+## all packages in this prject
+PACKAGES:=$(shell go list -f '{{.Name}}' ./... )
+
+OS:=$(shell uname -s)
+HARDWARE:=$(shell uname -m)
+
+export GOPATH:=$(PWD)/.build
+
+GODEP=$(GOPATH)/bin/godep
+
+.PHONY: all init deps update-deps build clean docker linux darwin release
+
+all: build
+
+$(GOPATH) stage:
+	@mkdir -p $@
+
+## retrieve godep tool
+$(GODEP): | $(GOPATH)
+	@echo "Installing godep"
+	@go get github.com/tools/godep
+
+## retrieve/restore dependencies with godep
+$(GOPATH)/.deps_installed: $(GODEP) Godeps/Godeps.json | $(GOPATH)
+	@echo "Retrieving dependencies"
+	@$(GODEP) restore
+	
+#	ensure this project can be imported
+	@mkdir -p $(shell dirname $(GOPATH)/src/$(PKG_PATH))
+	@test -e $(GOPATH)/src/$(PKG_PATH) || ln -s $(PWD) $(GOPATH)/src/$(PKG_PATH)
+	
+	@touch $@
+
+## just installs dependencies
+deps: $(GOPATH)/.deps_installed
+
+## update dependencies to their latest versions and save *all* dependencies
+update-deps: $(GOPATH)/.deps_installed
+	@cd $(GOPATH)/src/$(PKG_PATH) && ./update-deps.sh
+
+## build the binary for local use
+stage/$(NAME): $(GODEP) deps $(SOURCES) | stage
+	$(GODEP) go build -o $@ -ldflags '-X main.version $(VERSION)' -v .
+
+## shortcut
+build: stage/$(NAME)
+
+clean:
+	rm -rf .build stage release
+
+## build per-platform binaries for release
+linux darwin: $(GODEP) deps $(SOURCES) | stage
+	GOOS=$@ $(GODEP) go build -o release/$(NAME) -ldflags '-X main.version $(VERSION)' -v .
+	cd release && tar -zcf $(NAME)_$(VERSION)_$(@)_$(HARDWARE).tgz $(NAME)
+	rm -f release/$(NAME)
+
+docker:
 	docker build -t registrator .
 
-release:
-	rm -rf release
-	mkdir release
-	GOOS=linux godep go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_linux_$(HARDWARE).tgz $(NAME)
-	GOOS=darwin godep go build -o release/$(NAME)
-	cd release && tar -zcf $(NAME)_$(VERSION)_darwin_$(HARDWARE).tgz $(NAME)
-	rm release/$(NAME)
+release: linux darwin
 	echo "$(VERSION)" > release/version
 	echo "progrium/$(NAME)" > release/repo
 	gh-release # https://github.com/progrium/gh-release
-
-.PHONY: release

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -14,7 +14,9 @@ go list -f '{{ range .Imports }}{{.}} {{end}}' \
     | while read x; do
         echo "==> updating $x"
         go get -u $x
-        godep update $x
+        ## might fail if we change the import path of a package; expect the save
+        ## to save us
+        godep update $x || true
     done
 
 ## save new deps pulled in by updates

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -13,6 +13,7 @@ go list -f '{{ range .Imports }}{{.}} {{end}}' \
     | egrep '\.(com|org|net)/' \
     | while read x; do
         echo "==> updating $x"
+        go get -u $x
         godep update $x
     done
 

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## helper script for updating dependencies; too much shell-fu for a Makefile
+## expects GOPATH to be set, requires godep
+
+set -e
+
+export PATH="${GOPATH}/bin:${PATH}"
+
+## update existing deps; exclude built-in packages
+go list -f '{{ range .Imports }}{{.}} {{end}}' \
+    | tr ' ' '\n' \
+    | egrep '\.(com|org|net)/' \
+    | while read x; do
+        echo "==> updating $x"
+        godep update $x
+    done
+
+## save new deps pulled in by updates
+godep save

--- a/update-deps.sh
+++ b/update-deps.sh
@@ -5,12 +5,15 @@
 
 set -e
 
+PKG_PATH="${1}"
 export PATH="${GOPATH}/bin:${PATH}"
 
 ## update existing deps; exclude built-in packages
-go list -f '{{ range .Imports }}{{.}} {{end}}' \
+go list -f '{{ range .Imports }}{{.}} {{end}}' ./... \
     | tr ' ' '\n' \
+    | egrep -v "${PKG_PATH}" \
     | egrep '\.(com|org|net)/' \
+    | sort -u \
     | while read x; do
         echo "==> updating $x"
         go get -u $x
@@ -20,4 +23,4 @@ go list -f '{{ range .Imports }}{{.}} {{end}}' \
     done
 
 ## save new deps pulled in by updates
-godep save
+godep save ./...


### PR DESCRIPTION
This improved Makefile allows anyone to download the source and build by just running `make`.  It downloads the [godep](https://github.com/tools/godep) tool, runs `godep restore`, and then builds `stage/registrator`.  I've attempted to preserve the original `release` target, and have renamed the previous `build` target (which builds the Docker image) as `docker`.

I've also added the `update-deps` target for updating existing dependencies and saving new (and transitive) dependencies.

The build currently fails because #80 has not been pulled in.