### PR TITLE
Added discovery for services running with --net=host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Registrator was designed to just be run as a container. You must pass the Docker
 		-v /var/run/docker.sock:/tmp/docker.sock \
 		-h $HOSTNAME progrium/registrator <registry-uri>
 
+### Host mode services
+
+Registrator will discover services running in Docker net=host mode provided that their exposed ports are explicitly listed using the -p flag:
+
+	$ docker run --net=host -p 8080:8080 -p 8443:8443 ...
+		
 ### Registry URIs
 
 The registry backend to use is defined by a URI. The scheme is the supported registry name, and an address. Registries based on key-value stores like etcd and Zookeeper (not yet supported) can specify a key path to use to prefix service definitions. Registries may also use query params for other options. See also [Adding support for other service registries](#adding-support-for-other-service-registries).

--- a/bridge.go
+++ b/bridge.go
@@ -140,6 +140,27 @@ type RegistryBridge struct {
 	services map[string][]*Service
 }
 
+func MakePublishedPort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) PublishedPort {
+	var hp, hip string
+	if len(published) > 0 {
+		hp = published[0].HostPort
+		hip = published[0].HostIP
+	}
+	if (hip == "") {
+		hip = "0.0.0.0"
+	}		
+	p := strings.Split(string(port), "/")
+	return PublishedPort{
+		HostPort:    hp,
+		HostIP:      hip,
+		HostName:    container.Config.Hostname,
+		ExposedPort: p[0],
+		ExposedIP:   container.NetworkSettings.IPAddress,
+		PortType:    p[1],
+		Container:   container,
+	}
+}
+
 func (b *RegistryBridge) Add(containerId string) {
 	b.Lock()
 	defer b.Unlock()
@@ -149,24 +170,16 @@ func (b *RegistryBridge) Add(containerId string) {
 		return
 	}
 
-	ports := make([]PublishedPort, 0)
+	ports := make(map[string]PublishedPort)
+	
+	// Extract configured host port mappings, relevant when using --net=host
+	for port, published := range container.HostConfig.PortBindings {
+		ports[string(port)] = MakePublishedPort(container, port, published)
+	}
+	
+	// Extract runtime port mappings, relevant when using e.g. --net=bridge
 	for port, published := range container.NetworkSettings.Ports {
-		var hp, hip string
-		if len(published) > 0 {
-			hp = published[0].HostPort
-			hip = published[0].HostIP
-		}
-		p := strings.Split(string(port), "/")
-		ports = append(ports, PublishedPort{
-			HostPort:    hp,
-			HostIP:      hip,
-			HostName:    container.Config.Hostname,
-			ExposedPort: p[0],
-			ExposedIP:   container.NetworkSettings.IPAddress,
-			PortType:    p[1],
-			Container:   container,
-		})
-		// }
+		ports[string(port)] = MakePublishedPort(container, port, published)
 	}
 
 	for _, port := range ports {
@@ -190,7 +203,7 @@ func (b *RegistryBridge) Add(containerId string) {
 		log.Println("registrator: added:", container.ID[:12], service.ID)
 	}
 
-	if len(b.services) == 0 {
+	if len(b.services[container.ID]) == 0 {
 		log.Println("registrator: ignored:", container.ID[:12], "no published ports")
 	}
 }


### PR DESCRIPTION
Containers started with --net=host were not discovered by registrator because their NetworkSettings.Ports section is empty. The corresponding information is however present in HostConfig.PortBindings for containers started using net=host.

This patch adds optional support for HostConfig.PortBindings, but defaults to the configuration in NetworkSettings.Ports to ensure backwards compatibility.