### PR TITLE
Use the service Address field of Consul 0.5.0 RC1+

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/armon/consul-api"
+	consulapi "github.com/hashicorp/consul/api"
 )
 
 const DefaultInterval = "10s"

--- a/consul.go
+++ b/consul.go
@@ -66,6 +66,7 @@ func (r *ConsulRegistry) registerWithAgent(service *Service) error {
 	registration.Name = service.Name
 	registration.Port = service.Port
 	registration.Tags = service.Tags
+	registration.Address = service.IP
 	registration.Check = r.buildCheck(service)
 
 	return r.client.Agent().ServiceRegister(registration)


### PR DESCRIPTION
This PR is work in progress and depends on unreleased Consul features (available in master branch) and the hashicorp/consul#627 pull request to add address support to the consul go api.