### PR TITLE
Fix import comment for move to "gliderlabs"

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -1,4 +1,4 @@
-package main // import "github.com/progrium/registrator"
+package main // import "github.com/gliderlabs/registrator"
 
 import (
 	"errors"


### PR DESCRIPTION
Fixes error running “go get -u github.com/gliderlabs/registrator” due
to the import check.