### PR TITLE
Only deregister containers cleanly shutdown

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -15,10 +15,11 @@ import (
 
 type Bridge struct {
 	sync.Mutex
-	registry RegistryAdapter
-	docker   *dockerapi.Client
-	services map[string][]*Service
-	config   Config
+	registry       RegistryAdapter
+	docker         *dockerapi.Client
+	services       map[string][]*Service
+	deadContainers map[string]*DeadContainer
+	config         Config
 }
 
 func New(docker *dockerapi.Client, adapterUri string, config Config) *Bridge {
@@ -37,10 +38,11 @@ func New(docker *dockerapi.Client, adapterUri string, config Config) *Bridge {
 	}
 	log.Println("Using", uri.Scheme, "adapter:", uri)
 	return &Bridge{
-		docker:   docker,
-		config:   config,
-		registry: adapter,
-		services: make(map[string][]*Service),
+		docker:         docker,
+		config:         config,
+		registry:       adapter,
+		services:       make(map[string][]*Service),
+		deadContainers: make(map[string]*DeadContainer),
 	}
 }
 
@@ -51,23 +53,24 @@ func (b *Bridge) Add(containerId string) {
 }
 
 func (b *Bridge) Remove(containerId string) {
-	b.Lock()
-	defer b.Unlock()
-	for _, service := range b.services[containerId] {
-		log.Println("removing:", containerId[:12], service.ID)
-		err := retry(func() error {
-			return b.registry.Deregister(service)
-		})
-		if err != nil {
-			log.Println("deregister failed:", service.ID, err)
-		}
-	}
-	delete(b.services, containerId)
+	b.remove(containerId, true)
+}
+
+func (b *Bridge) RemoveOnExit(containerId string) {
+	b.remove(containerId, b.didExitCleanly(containerId))
 }
 
 func (b *Bridge) Refresh() {
 	b.Lock()
 	defer b.Unlock()
+
+	for containerId, deadContainer := range b.deadContainers {
+		deadContainer.TTL -= b.config.RefreshInterval
+		if deadContainer.TTL <= 0 {
+			delete(b.deadContainers, containerId)
+		}
+	}
+
 	for containerId, services := range b.services {
 		for _, service := range services {
 			log.Println("refreshing:", containerId[:12], service.ID)
@@ -113,6 +116,11 @@ func (b *Bridge) Sync(quiet bool) {
 }
 
 func (b *Bridge) add(containerId string, quiet bool) {
+	if d := b.deadContainers[containerId]; d != nil {
+		b.services[containerId] = d.Services
+		delete(b.deadContainers, containerId)
+	}
+
 	if b.services[containerId] != nil {
 		log.Println("container, ", containerId[:12], ", already exists, ignoring")
 		// Alternatively, remove and readd or resubmit.
@@ -232,4 +240,47 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.TTL = b.config.RefreshTtl
 
 	return service
+}
+
+func (b *Bridge) remove(containerId string, deregister bool) {
+	b.Lock()
+	defer b.Unlock()
+
+	if deregister {
+		deregisterAll := func(services []*Service) {
+			for _, service := range services {
+				log.Println("removing:", containerId[:12], service.ID)
+				err := retry(func() error {
+					return b.registry.Deregister(service)
+				})
+				if err != nil {
+					log.Println("deregister failed:", service.ID, err)
+				}
+			}
+		}
+		deregisterAll(b.services[containerId])
+		if d := b.deadContainers[containerId]; d != nil {
+			deregisterAll(d.Services)
+			delete(b.deadContainers, containerId)
+		}
+	} else if b.config.RefreshTtl != 0 && b.services[containerId] != nil {
+		// need to stop the refreshing, but can't delete it yet
+		b.deadContainers[containerId] = &DeadContainer{b.config.RefreshTtl, b.services[containerId]}
+	}
+	delete(b.services, containerId)
+}
+
+func (b *Bridge) didExitCleanly(containerId string) bool {
+	container, err := b.docker.InspectContainer(containerId)
+	if _, ok := err.(*dockerapi.NoSuchContainer); ok {
+		// the container has already been removed from Docker
+		// e.g. probabably run with "--rm" to remove immediately
+		// so its exit code is not accessible
+		log.Printf("registrator: container %v was removed, could not fetch exit code", containerId[:12])
+		return true
+	} else if err != nil {
+		log.Printf("registrator: error fetching status for container %v on \"die\" event: %v\n", containerId[:12], err)
+		return false
+	}
+	return !container.State.Running && container.State.ExitCode == 0
 }

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -57,7 +57,7 @@ func (b *Bridge) Remove(containerId string) {
 }
 
 func (b *Bridge) RemoveOnExit(containerId string) {
-	b.remove(containerId, b.didExitCleanly(containerId))
+	b.remove(containerId, b.config.DeregisterCheck == "always" || b.didExitCleanly(containerId))
 }
 
 func (b *Bridge) Refresh() {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -24,6 +24,7 @@ type Config struct {
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int
+	DeregisterCheck string
 }
 
 type Service struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -38,6 +38,11 @@ type Service struct {
 	Origin ServicePort
 }
 
+type DeadContainer struct {
+	TTL      int
+	Services []*Service
+}
+
 type ServicePort struct {
 	HostPort          string
 	HostIP            string

--- a/registrator.go
+++ b/registrator.go
@@ -109,9 +109,9 @@ func main() {
 		switch msg.Status {
 		case "start":
 			go b.Add(msg.ID)
-		case "stop":
-			go b.Remove(msg.ID)
 		case "die":
+			go b.RemoveOnExit(msg.ID)
+		case "stop", "kill":
 			go b.Remove(msg.ID)
 		}
 	}

--- a/registrator.go
+++ b/registrator.go
@@ -20,6 +20,7 @@ var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service T
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
 var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
+var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -55,12 +56,17 @@ func main() {
 	docker, err := dockerapi.NewClient(getopt("DOCKER_HOST", "unix:///tmp/docker.sock"))
 	assert(err)
 
+	if *deregister != "always" && *deregister != "on-success" {
+		assert(errors.New("-deregister must be \"always\" or \"on-success\""))
+	}
+
 	b := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,
+		DeregisterCheck: *deregister,
 	})
 
 	// Start event listener before listing containers to avoid missing anything


### PR DESCRIPTION
Provides a fix for #82.

This only deregisters containers that:
* exited cleanly with status "0"
* shutdown with docker "stop" or "kill"

Otherwise the container is assumed to have exited unexpectedly. It is
left in the service registry so that health checks can detect that the
container failed.

When a container dies with a non-zero exit, but a refresh TTL is set, the service is immediately removed from the list to refresh, but not deregistered. However, it needs to retain the list of Service objects in case the "die" event is followed by a "stop" or "kill" event, and can then be deregistered. So, the info is moved to  "deadContainers" map, which will be removed if the TTL is reached without another either being deregistered or restarted.