### PR TITLE
Register docker container private IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ By default, when registering a service, registrator will assign the service addr
 
 If the argument `-internal` is passed, registrator will register the docker0 internal ip and port instead of the host mapped ones. (etcd, consul, and skydns2 for now). The `-internal` argument must be passed before the `<registry-uri>` argument.
 
+If the argument `-private` is passed, registrator will register the docker container ip address. This can be useful when running containers on different hosts are able to connect to each other, such as with Kubernetes. Note that this will only actually work with Consul 10.5.0 and later.
+
 The `-resync` argument controls how often registrator will query Docker for all containers and reregister all services.  This allows registrator and the service registry to get back in sync if they fall out of sync.  The time is measured in seconds, and if set to zero will not resync.
 
 The consul backend does not support automatic expiry of stale registrations after some TTL. Instead, TTL checks must be configured (see below). For backends that do support TTL expiry, registrator can be started with the `-ttl` and `-ttl-refresh` arguments (both disabled by default).

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -138,7 +138,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	}
 
 	for _, port := range ports {
-		if b.config.Internal != true && port.HostPort == "" {
+		if b.config.Internal != true && b.config.PrivateIP != true &&  port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			}
@@ -204,6 +204,9 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	var p int
 	if b.config.Internal == true {
 		service.IP = port.ExposedIP
+		p, _ = strconv.Atoi(port.ExposedPort)
+	} else if b.config.PrivateIP == true {
+		service.IP = container.NetworkSettings.IPAddress
 		p, _ = strconv.Atoi(port.ExposedPort)
 	} else {
 		service.IP = port.HostIP

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -21,6 +21,7 @@ type RegistryAdapter interface {
 type Config struct {
 	HostIp          string
 	Internal        bool
+	PrivateIP       bool
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int

--- a/registrator.go
+++ b/registrator.go
@@ -16,6 +16,7 @@ var Version string
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
+var private = flag.Bool("private", false, "Use container private ip address")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -43,6 +44,11 @@ func main() {
 
 	flag.Parse()
 
+	if(*internal && *private) {
+		fmt.Println("Cannot specify both --internal and --private")
+		os.Exit(1)
+	}
+
 	if *hostIp != "" {
 		log.Println("Forcing host IP to", *hostIp)
 	}
@@ -58,6 +64,7 @@ func main() {
 	b := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
+	        PrivateIP:       *private,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,


### PR DESCRIPTION
Allow registration of private (ie, docker container internal) ip addresses for cases when those addresses are actually reachable from other machines in the cluster (eg, Kubernetes on GCE).
