### PR TITLE
Interpolate Consul service health checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - More error logging for registries
 - Support for services on containers with `--net=host`
 - Added `extensions.go` file for adding/disabling components
+- Interpolate SERVICE_PORT and SERVICE_IP in SERVICE_X_CHECK_SCRIPT
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ This runs the command using this service's container image as a separate contain
 
 	SERVICE_CHECK_SCRIPT=curl --silent --fail example.com
 
-The default interval for any non-TTL check is 10s, but you can set it with `_CHECK_INTERVAL`.
+The default interval for any non-TTL check is 10s, but you can set it with `_CHECK_INTERVAL`. The check command will be
+interpolated with the `$SERVICE_IP` and `$SERVICE_PORT` placeholders:
+
+	SERVICE_CHECK_SCRIPT=nc $SERVICE_IP $SERVICE_PORT | grep OK
 
 #### Register a TTL health check
 

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strings"
 
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
@@ -13,6 +14,12 @@ const DefaultInterval = "10s"
 
 func init() {
 	bridge.Register(new(Factory), "consul")
+}
+
+func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
+	withIp := strings.Replace(script, "$SERVICE_IP", service.Origin.HostIP, -1)
+	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
+	return withPort
 }
 
 type Factory struct{}
@@ -63,7 +70,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
 		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
 	} else if script := service.Attrs["check_script"]; script != "" {
-		check.Script = script
+		check.Script = r.interpolateService(script, service)
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else {


### PR DESCRIPTION
Similar to the request in #58, this patch adds the interpolation of
service IPs and ports for Consul's SERVICE_CHECK_SCRIPT using the
placeholders, SERVICE_PORT and SERVICE_IP:

  SERVICE_CHECK_SCRIPT=nc $SERVICE_IP $SERVICE_PORT | grep OK

To keep things simple, each check is specific only to the service in
question; specifically, the check does not have a full view of the
container and all of its ports.