### PR TITLE
Support reverse DNS look-ups for the SkyDNS backend

### DIFF
--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -1,7 +1,9 @@
 package skydns2
 
 import (
+	"errors"
 	"log"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -26,12 +28,13 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 		log.Fatal("skydns2: dns domain required e.g.: skydns2://<host>/<domain>")
 	}
 
-	return &Skydns2Adapter{client: etcd.NewClient(urls), path: domainPath(uri.Path[1:])}
+	return &Skydns2Adapter{client: etcd.NewClient(urls), path: domainPath(uri.Path[1:]), domain: uri.Path[1:]}
 }
 
 type Skydns2Adapter struct {
 	client *etcd.Client
 	path   string
+	domain string
 }
 
 func (r *Skydns2Adapter) Ping() error {
@@ -49,6 +52,27 @@ func (r *Skydns2Adapter) Register(service *bridge.Service) error {
 	_, err := r.client.Set(r.servicePath(service), record, uint64(service.TTL))
 	if err != nil {
 		log.Println("skydns2: failed to register service:", err)
+		return err
+	}
+
+	// Only setup reverse DNS mappings if the service's IP is unique.
+	// Anything else does not make sense right now as SkyDNS 2 only supports one
+	// host per entry type and overwriting the reverse DNS entry for every service
+	// exposed on the host may lead to confusing look ups.
+	if service.Origin.ExposedIP != service.IP {
+		return nil
+	}
+
+	raddr, err := reverseDomainName(service.Origin.ExposedIP)
+	if err != nil {
+		log.Println("skydns2: failed to determine reverse DNS entry for service:", err)
+		return err
+	}
+
+	record = `{"host":"` + r.serviceDomainName(service) + `"}`
+	_, err = r.client.Set(domainPath(raddr), record, uint64(service.TTL))
+	if err != nil {
+		log.Println("skydns2: failed to register reverse DNS entry:", err)
 	}
 	return err
 }
@@ -57,6 +81,22 @@ func (r *Skydns2Adapter) Deregister(service *bridge.Service) error {
 	_, err := r.client.Delete(r.servicePath(service), false)
 	if err != nil {
 		log.Println("skydns2: failed to register service:", err)
+	}
+
+	// A mapping was only setup if the service's IP is unique
+	if service.Origin.ExposedIP != service.IP {
+		return err
+	}
+
+	raddr, err := reverseDomainName(service.IP)
+	if err != nil {
+		log.Println("skydns2: failed to determine reverse DNS entry for service:", err)
+		return err
+	}
+
+	_, err = r.client.Delete(domainPath(raddr), false)
+	if err != nil {
+		log.Println("skydns2: Failed to deregister reverse DNS entry")
 	}
 	return err
 }
@@ -69,10 +109,54 @@ func (r *Skydns2Adapter) servicePath(service *bridge.Service) string {
 	return r.path + "/" + service.Name + "/" + service.ID
 }
 
+func (r *Skydns2Adapter) serviceDomainName(service *bridge.Service) string {
+	return service.ID + "." + service.Name + "." + r.domain
+}
+
 func domainPath(domain string) string {
 	components := strings.Split(domain, ".")
 	for i, j := 0, len(components)-1; i < j; i, j = i+1, j-1 {
 		components[i], components[j] = components[j], components[i]
 	}
 	return "/skydns/" + strings.Join(components, "/")
+}
+
+func reverseDomainName(ip string) (string, error) {
+	const IPv4Domain = "in-addr.arpa."
+	const IPv6Domain = "ip6.arpa."
+
+	addr := net.ParseIP(ip)
+	if addr == nil {
+		return "", errors.New("Invalid IP Address")
+	}
+
+	ip4addr := addr.To4()
+	if ip4addr != nil {
+		domainName := make([]byte, 0, len(ip4addr)*4+len(IPv4Domain))
+		for x := len(ip4addr) - 1; x >= 0; x-- {
+			domainName = strconv.AppendUint(domainName, uint64(ip4addr[x]), 10)
+			domainName = append(domainName, '.')
+		}
+		domainName = append(domainName, IPv4Domain...)
+
+		return string(domainName), nil
+	}
+
+	ip16addr := addr.To16()
+	if ip16addr != nil {
+		domainName := make([]byte, 0, len(ip16addr)*4+len(IPv6Domain))
+		for x := len(ip16addr) - 1; x >= 0; x-- {
+			component := uint64(ip16addr[x])
+
+			domainName = strconv.AppendUint(domainName, component&0x0f, 16)
+			domainName = append(domainName, '.')
+			domainName = strconv.AppendUint(domainName, component>>4, 16)
+			domainName = append(domainName, '.')
+		}
+		domainName = append(domainName, IPv6Domain...)
+
+		return string(domainName), nil
+	}
+
+	return "", errors.New("Unsupported IP address format")
 }

--- a/skydns2/skydns2_test.go
+++ b/skydns2/skydns2_test.go
@@ -1,0 +1,55 @@
+package skydns2
+
+import (
+	"github.com/gliderlabs/registrator/bridge"
+	"net/url"
+	"testing"
+)
+
+func TestReverseDomainNameIPv4(t *testing.T) {
+	const ExpectedDomainName = "1.0.0.127.in-addr.arpa."
+
+	domainName, err := reverseDomainName("127.0.0.1")
+	if err != nil {
+		t.Error("Unexpected reverseDomainName call failure:", err)
+	}
+	if domainName != ExpectedDomainName {
+		t.Error("Unexpected result:", domainName, "!=", ExpectedDomainName)
+	}
+}
+
+func TestReverseDomainNameIPv6(t *testing.T) {
+	const ExpectedDomainName = "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+
+	domainName, err := reverseDomainName("2001:db8::567:89ab")
+	if err != nil {
+		t.Error("Unexpected reverseDomainName call failure", err)
+	}
+	if domainName != ExpectedDomainName {
+		t.Error("Unexpected result:", domainName, "!=", ExpectedDomainName)
+	}
+}
+
+func TestReverseDomainNameInvalid(t *testing.T) {
+	domainName, err := reverseDomainName("#")
+	if err == nil {
+		t.Error(`Expected reverse domain name construction to fail for invalid IP "#"`)
+	}
+	if domainName != "" {
+		t.Error("Expected empty domain name when construction failed but got", domainName)
+	}
+}
+
+func TestServiceDomainName(t *testing.T) {
+	const ExpectedDomainName = "1.test.skydns.local"
+
+	service := bridge.Service{ID: "1", Name: "test"}
+	u, _ := url.Parse("skydns2://127.0.0.1:4001/skydns.local")
+	adapter := new(Factory).New(u).(*Skydns2Adapter)
+
+	domainName := adapter.serviceDomainName(&service)
+
+	if domainName != ExpectedDomainName {
+		t.Error("Unexpected result:", domainName, "!=", ExpectedDomainName)
+	}
+}


### PR DESCRIPTION
SkyDNS supports serving PTR records making reverse DNS look-ups
possible. Support this by registering the container's IP address during
service registration.

This feature is only enabled if registrator was started with the
"-internal" parameter as multiple reverse DNS entries for the same IP
address are currently not supported by SkyDNS.