### PR TITLE
Skydns2 can work with both etcd v0 and v2

### DIFF
--- a/etcd/client-wrapper.go
+++ b/etcd/client-wrapper.go
@@ -1,0 +1,73 @@
+package etcd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"regexp"
+
+	etcd2 "github.com/coreos/go-etcd/etcd"
+	etcd "gopkg.in/coreos/go-etcd.v0/etcd"
+)
+
+type EtcdClient struct {
+	client  *etcd.Client
+	client2 *etcd2.Client
+}
+
+func NewEtcdClient(host string) (*EtcdClient, error) {
+	urls := make([]string, 0)
+	if host != "" {
+		urls = append(urls, "http://"+host)
+	} else {
+		urls = append(urls, "http://127.0.0.1:4001")
+	}
+
+	res, err := http.Get(urls[0] + "/version")
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving version: %s", err)
+	}
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	if match, _ := regexp.Match("0\\.4\\.*", body); match == true {
+		log.Println("etcd client: using v0 client")
+		return &EtcdClient{client: etcd.NewClient(urls)}, nil
+	}
+
+	return &EtcdClient{client2: etcd2.NewClient(urls)}, nil
+}
+
+func (e *EtcdClient) Ping() error {
+	var err error
+	if e.client != nil {
+		rr := etcd.NewRawRequest("GET", "version", nil, nil)
+		_, err = e.client.SendRequest(rr)
+	} else {
+		rr := etcd2.NewRawRequest("GET", "version", nil, nil)
+		_, err = e.client2.SendRequest(rr)
+	}
+	return err
+}
+
+func (e *EtcdClient) Set(path, value string, ttl uint64) error {
+	var err error
+	if e.client != nil {
+		_, err = e.client.Set(path, value, ttl)
+	} else {
+		_, err = e.client2.Set(path, value, ttl)
+	}
+	return err
+}
+
+func (e *EtcdClient) Delete(path string, recursive bool) error {
+	var err error
+	if e.client != nil {
+		_, err = e.client.Delete(path, recursive)
+	} else {
+		_, err = e.client2.Delete(path, recursive)
+	}
+	return err
+}

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/coreos/go-etcd/etcd"
 	"github.com/gliderlabs/registrator/bridge"
+	"github.com/gliderlabs/registrator/etcd"
 )
 
 func init() {
@@ -17,36 +17,31 @@ func init() {
 type Factory struct{}
 
 func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
-	urls := make([]string, 0)
-	if uri.Host != "" {
-		urls = append(urls, "http://"+uri.Host)
+	client, err := etcd.NewEtcdClient(uri.Host)
+	if err != nil {
+		log.Fatal("skydns2: can't allocate client:", err)
 	}
 
 	if len(uri.Path) < 2 {
 		log.Fatal("skydns2: dns domain required e.g.: skydns2://<host>/<domain>")
 	}
 
-	return &Skydns2Adapter{client: etcd.NewClient(urls), path: domainPath(uri.Path[1:])}
+	return &Skydns2Adapter{client: client, path: domainPath(uri.Path[1:])}
 }
 
 type Skydns2Adapter struct {
-	client *etcd.Client
+	client *etcd.EtcdClient
 	path   string
 }
 
 func (r *Skydns2Adapter) Ping() error {
-	rr := etcd.NewRawRequest("GET", "version", nil, nil)
-	_, err := r.client.SendRequest(rr)
-	if err != nil {
-		return err
-	}
-	return nil
+	return r.client.Ping()
 }
 
 func (r *Skydns2Adapter) Register(service *bridge.Service) error {
 	port := strconv.Itoa(service.Port)
 	record := `{"host":"` + service.IP + `","port":` + port + `}`
-	_, err := r.client.Set(r.servicePath(service), record, uint64(service.TTL))
+	err := r.client.Set(r.servicePath(service), record, uint64(service.TTL))
 	if err != nil {
 		log.Println("skydns2: failed to register service:", err)
 	}
@@ -54,7 +49,7 @@ func (r *Skydns2Adapter) Register(service *bridge.Service) error {
 }
 
 func (r *Skydns2Adapter) Deregister(service *bridge.Service) error {
-	_, err := r.client.Delete(r.servicePath(service), false)
+	err := r.client.Delete(r.servicePath(service), false)
 	if err != nil {
 		log.Println("skydns2: failed to register service:", err)
 	}


### PR DESCRIPTION
Add minimalistic etcd client wrapper used by etcd and skydns2 adapters.
