### PR TITLE
add option to ignore silent services

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -199,6 +199,10 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 
 	metadata := serviceMetaData(container.Config.Env, port.ExposedPort)
 
+	if b.config.IgnoreSilent == true && len(metadata) == 0 {
+		return nil
+	}
+
 	ignore := mapDefault(metadata, "ignore", "")
 	if ignore != "" {
 		return nil

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -25,6 +25,7 @@ type Config struct {
 	RefreshTtl      int
 	RefreshInterval int
 	DeregisterCheck string
+	IgnoreSilent    bool
 }
 
 type Service struct {

--- a/registrator.go
+++ b/registrator.go
@@ -21,6 +21,7 @@ var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
 var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
+var ignoreSilent = flag.Bool("ignore-silent", false, "Ignore services that do not expose metadata via SERVICE_ variables")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -67,6 +68,7 @@ func main() {
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
+		IgnoreSilent:    *ignoreSilent,
 	})
 
 	// Start event listener before listing containers to avoid missing anything


### PR DESCRIPTION
There are cases where you'd want only specific containers to be registered, and avoid accidental name collisions. The `-ignore-silent` option makes registrator ignore containers that do not explicitly expose any `SERVICE_` variables.