### PR TITLE
Consul: Use native HTTP checks instead of check-http wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Overall refactoring and cleanup
 - Decoupled registries into subpackages using extpoints
+- Replaced check-http script with Consul's native HTTP checks
+  (requires Consul >= 0.5)
 
 
 ## [v5] - 2015-02-18

--- a/README.md
+++ b/README.md
@@ -223,10 +223,12 @@ When using the Consul's service catalog backend, you can specify a health check 
 
 #### Basic HTTP health check
 
-This feature is only available when using the `check-http` script that comes with the [progrium/consul](https://github.com/progrium/docker-consul#health-checking-with-docker) container for Consul.
+This feature is only available when using Consul 0.5 or newer.
 
 	SERVICE_80_CHECK_HTTP=/health/endpoint/path
 	SERVICE_80_CHECK_INTERVAL=15s
+	# Optional, Consul default value is used when not specified
+	SERVICE_80_CHECK_TIMEOUT=1s
 
 It works for an HTTP service on any port, not just 80. If its the only service, you can also use `SERVICE_CHECK_HTTP`.
 

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -66,7 +66,10 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
 	check := new(consulapi.AgentServiceCheck)
 	if path := service.Attrs["check_http"]; path != "" {
-		check.Script = fmt.Sprintf("check-http %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, path)
+		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)
+		if timeout := service.Attrs["check_timeout"]; timeout != "" {
+			check.Timeout = timeout
+		}
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
 		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
 	} else if script := service.Attrs["check_script"]; script != "" {
@@ -76,7 +79,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else {
 		return nil
 	}
-	if check.Script != "" {
+	if check.Script != "" || check.HTTP != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {


### PR DESCRIPTION
This also adds support for HTTP check timeout

The benefits of this change are: removed dependency on check-http and much better behaviour when faced with unresponsive HTTP server (check-http would take tens of seconds, if not minutes, to timeout).

It is my understanding that this function would affect GH #156 (https://github.com/gliderlabs/registrator/issues/156#issuecomment-94525221) and GH #172.