### PR TITLE
Fix bug in etcd backend when connecting to etcd2

### DIFF
--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -52,8 +52,15 @@ type EtcdAdapter struct {
 }
 
 func (r *EtcdAdapter) Ping() error {
-	rr := etcd.NewRawRequest("GET", "version", nil, nil)
-	_, err := r.client.SendRequest(rr)
+	var err error
+	if r.client != nil {
+		rr := etcd.NewRawRequest("GET", "version", nil, nil)
+		_, err = r.client.SendRequest(rr)
+	} else {
+		rr := etcd2.NewRawRequest("GET", "version", nil, nil)
+		_, err = r.client2.SendRequest(rr)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
etcd & client instead of the etcd2 object and client2 objects were being used read from the server.  This caused a panic making the use of registrator against an etcd2 backend impossible.