### PR TITLE
AWS SNS as a backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ Note that the default `service-id` includes more than the container name (see be
 
 Publishes service registration events to AWS SNS. Each message will contain a custom `MessageAttribute` called `DOCKER.EVENT`, whose value will be one of:
 
- * `PING`
+ * `BACKEND_PING`
  * `SERVICE_REGISTER`
  * `SERVICE_DEREGISTER`
+ * `SERVICE_REFRESH`
 
 The `Message` body will be the JSON encoded `Service` struct (see [How it works](#how-it-works)).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Service registry bridge for Docker, sponsored by [Weave](http://weave.works).
 
-Registrator automatically register/deregisters services for Docker containers based on published ports and metadata from the container environment. Registrator supports [pluggable service registries](#adding-support-for-other-service-registries), which currently includes [Consul](http://www.consul.io/), [etcd](https://github.com/coreos/etcd) and [SkyDNS 2](https://github.com/skynetservices/skydns/).
+Registrator automatically register/deregisters services for Docker containers based on published ports and metadata from the container environment. Registrator supports [pluggable service registries](#adding-support-for-other-service-registries), which currently includes [Consul](http://www.consul.io/), [etcd](https://github.com/coreos/etcd), [SkyDNS 2](https://github.com/skynetservices/skydns/) and [Amazon Simple Notification Service](http://aws.amazon.com/sns/).
 
 By default, it can register services without any user-defined metadata. This means it works with *any* container, but allows the container author or Docker operator to override/customize the service definitions.
 
@@ -87,6 +87,22 @@ Using the second example, a service definition for a container with `service-nam
 Note that the default `service-id` includes more than the container name (see below). For legal per-container DNS hostnames, specify the `SERVICE_ID` in the environment of the container, e.g.:
 
 	docker run -d --name redis-1 -e SERVICE_ID=redis-1 -p 6379:6379 redis
+
+#### AWS SNS backend
+
+Publishes service registration events to AWS SNS. Each message will contain a custom `MessageAttribute` called `DOCKER.EVENT`, whose value will be one of:
+
+ * `PING`
+ * `SERVICE_REGISTER`
+ * `SERVICE_DEREGISTER`
+
+The `Message` body will be the JSON encoded `Service` struct (see [How it works](#how-it-works)).
+
+Example URIs:
+
+    $ registrator sns://arn:aws:sns:us-west-2:123456789012:my-sns-topic
+
+AWS configuration and credentials are discovered as per [convention](https://github.com/awslabs/aws-sdk-go#configuring-credentials).
 
 ## How it works
 

--- a/modules.go
+++ b/modules.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/gliderlabs/registrator/consulkv"
 	_ "github.com/gliderlabs/registrator/etcd"
 	_ "github.com/gliderlabs/registrator/skydns2"
+	_ "github.com/gliderlabs/registrator/sns"
 )

--- a/sns/sns.go
+++ b/sns/sns.go
@@ -70,5 +70,5 @@ func (r *SNSAdapter) Deregister(service *bridge.Service) error {
 }
 
 func (r *SNSAdapter) Refresh(service *bridge.Service) error {
-	return nil
+	return r.publish("SERVICE_REFRESH", service)
 }

--- a/sns/sns.go
+++ b/sns/sns.go
@@ -56,9 +56,8 @@ func (r *SNSAdapter) publish(event string, service *bridge.Service) error {
 	return nil
 }
 
-// Ping will fetch the SNS Topic attributes
 func (r *SNSAdapter) Ping() error {
-	return r.publish("PING", nil)
+	return r.publish("BACKEND_PING", nil)
 }
 
 func (r *SNSAdapter) Register(service *bridge.Service) error {

--- a/sns/sns.go
+++ b/sns/sns.go
@@ -32,19 +32,6 @@ type SNSAdapter struct {
 	topicArn string
 }
 
-// Ping will fetch the SNS Topic attributes
-func (r *SNSAdapter) Ping() error {
-	params := &sns.GetTopicAttributesInput{
-		TopicARN: aws.String(r.topicArn),
-	}
-	resp, err := r.svc.GetTopicAttributes(params)
-	if err != nil {
-		return err
-	}
-	log.Println(*(*resp.Attributes)["TopicArn"])
-	return nil
-}
-
 func (r *SNSAdapter) publish(event string, service *bridge.Service) error {
 	msg, err := json.MarshalIndent(service, "", "\t")
 	if err != nil {
@@ -65,8 +52,13 @@ func (r *SNSAdapter) publish(event string, service *bridge.Service) error {
 		return err
 	}
 
-	log.Println("Published to SNS: %s", resp.MessageID)
+	log.Println("Published to SNS:", *resp.MessageID)
 	return nil
+}
+
+// Ping will fetch the SNS Topic attributes
+func (r *SNSAdapter) Ping() error {
+	return r.publish("PING", nil)
 }
 
 func (r *SNSAdapter) Register(service *bridge.Service) error {

--- a/sns/sns.go
+++ b/sns/sns.go
@@ -1,0 +1,82 @@
+package sns
+
+import (
+	"encoding/json"
+	"log"
+	"net/url"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/sns"
+	"github.com/gliderlabs/registrator/bridge"
+)
+
+func init() {
+	bridge.Register(new(Factory), "sns")
+}
+
+type Factory struct{}
+
+func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
+	if uri.Host == "" {
+		log.Fatal("sns: ", uri)
+	}
+
+	return &SNSAdapter{
+		svc:      sns.New(nil),
+		topicArn: uri.Host,
+	}
+}
+
+type SNSAdapter struct {
+	svc      *sns.SNS
+	topicArn string
+}
+
+// Ping will fetch the SNS Topic attributes
+func (r *SNSAdapter) Ping() error {
+	params := &sns.GetTopicAttributesInput{
+		TopicARN: aws.String(r.topicArn),
+	}
+	resp, err := r.svc.GetTopicAttributes(params)
+	if err != nil {
+		return err
+	}
+	log.Println(*(*resp.Attributes)["TopicArn"])
+	return nil
+}
+
+func (r *SNSAdapter) publish(event string, service *bridge.Service) error {
+	msg, err := json.MarshalIndent(service, "", "\t")
+	if err != nil {
+		return err
+	}
+	params := &sns.PublishInput{
+		TopicARN: aws.String(r.topicArn),
+		Message:  aws.String(string(msg)),
+		MessageAttributes: &map[string]*sns.MessageAttributeValue{
+			"DOCKER.EVENT": &sns.MessageAttributeValue{
+				DataType:    aws.String("String"),
+				StringValue: aws.String(event),
+			},
+		},
+	}
+	resp, err := r.svc.Publish(params)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Published to SNS: %s", resp.MessageID)
+	return nil
+}
+
+func (r *SNSAdapter) Register(service *bridge.Service) error {
+	return r.publish("SERVICE_REGISTER", service)
+}
+
+func (r *SNSAdapter) Deregister(service *bridge.Service) error {
+	return r.publish("SERVICE_DEREGISTER", service)
+}
+
+func (r *SNSAdapter) Refresh(service *bridge.Service) error {
+	return nil
+}


### PR DESCRIPTION
Enabling SNS as a backend allows for more flexible handling of docker events. Subscribers to the topic can implement more complex logic around service registration.

See README updates for an explanation of how to use the backend.