### PR TITLE
Using labels instead of environment variables to define metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Most of these (except `IP` and `Port`) can be overridden by container environmen
 Additional supported metadata in the same format `SERVICE_<metadata>`.
 IGNORE: Any value for ignore tells registrator to ignore this entire container and all associated ports.
 
-Since metadata is stored as environment variables, the container author can include their own metadata defined in the Dockerfile. The operator will still be able to override these author-defined defaults.
+Starting with Docker version 1.6 and up, you can use labels instead of environment variables to service definitions.
+
+Since metadata is stored as environment variables or labels, the container author can include their own metadata defined in the Dockerfile. The operator will still be able to override these author-defined defaults.
 
 ### Single service with defaults
 
@@ -199,6 +201,24 @@ Results in two `Service` objects:
 			"Attrs": {}
 		}
 	]
+
+### Using labels to define metadata
+
+	$ docker run -d --name redis.0 -p 10000:6379 \
+		-l "SERVICE_NAME=db" \
+		-l "SERVICE_TAGS=master,backups" \
+		-l "SERVICE_REGION=us2" dockerfile/redis
+
+Results in `Service`:
+
+	{
+		"ID": "hostname:redis.0:6379",
+		"Name": "db",
+		"Port": 10000,
+		"IP": "192.168.1.102",
+		"Tags": ["master", "backups"],
+		"Attrs": {"region": "us2"}
+	}
 
 ## Adding support for other service registries
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -197,7 +197,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		port.HostIP = b.config.HostIp
 	}
 
-	metadata := serviceMetaData(container.Config.Env, port.ExposedPort)
+	metadata := serviceMetaData(container.Config, port.ExposedPort)
 
 	ignore := mapDefault(metadata, "ignore", "")
 	if ignore != "" {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -30,9 +30,13 @@ func combineTags(tagParts ...string) []string {
 	return tags
 }
 
-func serviceMetaData(env []string, port string) map[string]string {
+func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
+	meta := config.Env
+	for k, v := range config.Labels {
+		meta = append(meta, k + "=" + v)
+	}
 	metadata := make(map[string]string)
-	for _, kv := range env {
+	for _, kv := range meta {
 		kvp := strings.SplitN(kv, "=", 2)
 		if strings.HasPrefix(kvp[0], "SERVICE_") && len(kvp) > 1 {
 			key := strings.ToLower(strings.TrimPrefix(kvp[0], "SERVICE_"))


### PR DESCRIPTION
This PR adds support for Docker 1.6 labels to use those instead of environment variables for for service metadata. 