### PR TITLE
Add service cleanup to consul registry

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -83,14 +83,14 @@ func (b *Bridge) Refresh() {
 	}
 }
 
-func (b *Bridge) Sync(quiet bool) {
+func (b *Bridge) Sync(quiet bool) error {
 	b.Lock()
 	defer b.Unlock()
 
 	containers, err := b.docker.ListContainers(dockerapi.ListContainersOptions{})
 	if err != nil && quiet {
 		log.Println("error listing containers, skipping sync")
-		return
+		return err
 	} else if err != nil && !quiet {
 		log.Fatal(err)
 	}
@@ -112,6 +112,19 @@ func (b *Bridge) Sync(quiet bool) {
 			}
 		}
 	}
+
+	return nil
+}
+
+func (b *Bridge) Cleanup() error {
+	serviceList := map[string]*Service{}
+	for _, servicesOfContainer := range b.services {
+		for _, service := range servicesOfContainer {
+			serviceList[service.ID] = service
+		}
+	}
+
+	return b.registry.Cleanup(serviceList)
 }
 
 func (b *Bridge) add(containerId string, quiet bool) {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -16,6 +16,7 @@ type RegistryAdapter interface {
 	Register(service *Service) error
 	Deregister(service *Service) error
 	Refresh(service *Service) error
+	Cleanup(validServices map[string]*Service) error
 }
 
 type Config struct {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -11,6 +11,7 @@ import (
 )
 
 const DefaultInterval = "10s"
+const ServiceIdPrefix = "registrator-"
 
 func init() {
 	bridge.Register(new(Factory), "consul")
@@ -54,7 +55,7 @@ func (r *ConsulAdapter) Ping() error {
 
 func (r *ConsulAdapter) Register(service *bridge.Service) error {
 	registration := new(consulapi.AgentServiceRegistration)
-	registration.ID = service.ID
+	registration.ID = ServiceIdPrefix + service.ID
 	registration.Name = service.Name
 	registration.Port = service.Port
 	registration.Tags = service.Tags
@@ -87,9 +88,33 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 }
 
 func (r *ConsulAdapter) Deregister(service *bridge.Service) error {
-	return r.client.Agent().ServiceDeregister(service.ID)
+	return r.client.Agent().ServiceDeregister(ServiceIdPrefix + service.ID)
 }
 
 func (r *ConsulAdapter) Refresh(service *bridge.Service) error {
+	return nil
+}
+
+func (r *ConsulAdapter) Cleanup(validServices map[string]*bridge.Service) error {
+	agentServices, err := r.client.Agent().Services()
+	if err != nil {
+		return err
+	}
+
+	for id, _ := range agentServices {
+		if !strings.HasPrefix(id, ServiceIdPrefix) {
+			continue
+		}
+
+		idWithoutPrefix := strings.TrimPrefix(id, ServiceIdPrefix)
+
+		service, ok := validServices[idWithoutPrefix]
+		if !ok || service == nil {
+			if err := r.client.Agent().ServiceDeregister(id); err != nil {
+				log.Println("consul deregister during cleanup failed:", id, err)
+			}
+		}
+	}
+
 	return nil
 }

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -110,6 +110,7 @@ func (r *ConsulAdapter) Cleanup(validServices map[string]*bridge.Service) error 
 
 		service, ok := validServices[idWithoutPrefix]
 		if !ok || service == nil {
+			log.Println("cleanup:", idWithoutPrefix)
 			if err := r.client.Agent().ServiceDeregister(id); err != nil {
 				log.Println("consul deregister during cleanup failed:", id, err)
 			}

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -68,3 +68,7 @@ func (r *ConsulKVAdapter) Deregister(service *bridge.Service) error {
 func (r *ConsulKVAdapter) Refresh(service *bridge.Service) error {
 	return nil
 }
+
+func (r *ConsulKVAdapter) Cleanup(validServices map[string]*bridge.Service) error {
+	return nil
+}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -104,3 +104,7 @@ func (r *EtcdAdapter) Deregister(service *bridge.Service) error {
 func (r *EtcdAdapter) Refresh(service *bridge.Service) error {
 	return r.Register(service)
 }
+
+func (r *EtcdAdapter) Cleanup(validServices map[string]*bridge.Service) error {
+	return nil
+}

--- a/registrator.go
+++ b/registrator.go
@@ -74,7 +74,14 @@ func main() {
 	assert(docker.AddEventListener(events))
 	log.Println("Listening for Docker events ...")
 
-	b.Sync(false)
+	// sync services and then cleanup old services
+	if err = b.Sync(false); err != nil {
+		log.Println("initial sync failed, skipping cleanup:", err)
+	} else {
+		if err = b.Cleanup(); err != nil {
+			log.Println("cleanup failed:", err)
+		}
+	}
 
 	quit := make(chan struct{})
 

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -65,6 +65,10 @@ func (r *Skydns2Adapter) Refresh(service *bridge.Service) error {
 	return r.Register(service)
 }
 
+func (r *Skydns2Adapter) Cleanup(validServices map[string]*bridge.Service) error {
+	return nil
+}
+
 func (r *Skydns2Adapter) servicePath(service *bridge.Service) string {
 	return r.path + "/" + service.Name + "/" + service.ID
 }


### PR DESCRIPTION
When stopping registrator uncleanly (either by SIGKILL or when consul is not
available) it has no chance to cleanup its registered services with consul.
This patch adds a Cleanup method to the Registry interface and implements it
for consul to find its service again (ID prefix with "registrator-") and remove
those which are not valid anymore.