### PR TITLE
Service Interpolation IP's.

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -18,7 +18,7 @@ func init() {
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
 	withIp := strings.Replace(script, "$SERVICE_IP", service.IP, -1)
-	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
+	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Port, -1)
 	return withPort
 }
 

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -17,7 +17,7 @@ func init() {
 }
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
-	withIp := strings.Replace(script, "$SERVICE_IP", service.Origin.HostIP, -1)
+	withIp := strings.Replace(script, "$SERVICE_IP", service.IP, -1)
 	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
 	return withPort
 }


### PR DESCRIPTION
This logic should provide the correct health check host/ports based on what is actually being created in the service definition.(ie: if you override with -ip or -internal/etc.).  This functions as expected with a consul agent running outside of the container.