### PR TITLE
Updating Interpolation IP/Port to match service definition.

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"fmt"
+	"strconv"
 	"log"
 	"net/url"
 	"strings"
@@ -17,8 +18,8 @@ func init() {
 }
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
-	withIp := strings.Replace(script, "$SERVICE_IP", service.Origin.HostIP, -1)
-	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
+	withIp := strings.Replace(script, "$SERVICE_IP", service.IP, -1)
+	withPort := strings.Replace(withIp, "$SERVICE_PORT", strconv.Itoa(service.Port), -1)
 	return withPort
 }
 


### PR DESCRIPTION
This logic should provide the correct health check host/ports based on what is actually being created in the service definition.(ie: if you override with -ip or -internal/etc.). This functions as expected with a consul agent running outside of the container.