### PR TITLE
Missing protocol fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
+DEV_RUN_OPTS ?= consul:
 
 dev:
 	docker build -f Dockerfile.dev -t $(NAME):dev .
 	docker run --rm \
 		-v /var/run/docker.sock:/tmp/docker.sock \
-		$(NAME):dev /bin/registrator consul:
+		$(NAME):dev /bin/registrator $(DEV_RUN_OPTS)
 
 build:
 	mkdir -p build

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -56,7 +56,7 @@ func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
 }
 
 func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
-	var hp, hip string
+	var hp, hip, ep, ept string
 	if len(published) > 0 {
 		hp = published[0].HostPort
 		hip = published[0].HostIP
@@ -64,13 +64,19 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	if hip == "" {
 		hip = "0.0.0.0"
 	}
-	p := strings.Split(string(port), "/")
+	exposedPort := strings.Split(string(port), "/")
+	ep = exposedPort[0]
+	if len(exposedPort) == 2 {
+		ept = exposedPort[1]
+	} else {
+		ept = "tcp"  // default
+	}
 	return ServicePort{
 		HostPort:          hp,
 		HostIP:            hip,
-		ExposedPort:       p[0],
+		ExposedPort:       ep,
 		ExposedIP:         container.NetworkSettings.IPAddress,
-		PortType:          p[1],
+		PortType:          ept,
 		ContainerID:       container.ID,
 		ContainerHostname: container.Config.Hostname,
 		container:         container,


### PR DESCRIPTION
Hi :)

This PR is a patch for the crash outlined at https://github.com/gliderlabs/registrator/issues/226

> The cause of the crash is when the protocol from the HostPort portion is omitted in the API call (which the API is OK with.. it must default to TCP?)

I also added a Makefile tweak for the dev section to support more rapid dev testing (whilst maintaining the existing default), e.g:

`DEV_RUN_OPTS="-internal consul://consul.docker:8500" make dev`