### PR TITLE
Use container name instead of image name (Optional)

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -176,6 +176,11 @@ func (b *Bridge) add(containerId string, quiet bool) {
 func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
+	
+	if b.config.ContainerName {
+		defaultName = path.Base(container.Name)
+	}
+
 	if isgroup {
 		defaultName = defaultName + "-" + port.ExposedPort
 	}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -25,6 +25,7 @@ type Config struct {
 	RefreshTtl      int
 	RefreshInterval int
 	DeregisterCheck string
+	ContainerName	bool
 }
 
 type Service struct {

--- a/registrator.go
+++ b/registrator.go
@@ -21,6 +21,7 @@ var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
 var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
+var containerName = flag.Bool("use-container-name",false,"Use container name instead of the image name")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -67,6 +68,7 @@ func main() {
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
+		ContainerName:	 *containerName,
 	})
 
 	// Start event listener before listing containers to avoid missing anything


### PR DESCRIPTION
Use container name instead of image name to register the service ,  I found this necessary if you want to use the scale function in docker-compose