### PR TITLE
Add netfilter (ipv6) support

### DIFF
--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -104,3 +104,44 @@ SkyDNS requires the service ID to be a valid DNS hostname, so this backend requi
 override service ID to a valid DNS name. Example:
 
 	$ docker run -d --name redis-1 -e SERVICE_ID=redis-1 -p 6379:6379 redis
+
+## Netfilter
+
+        netfilter://mychain/myset
+
+When using IPv6 containers, the NAT is gone and your container and ports are by default reachable. You can use this module to firewall those.
+
+If no chain/set is specified, it will default to `netfilter://FORWARD_direct/containerports`
+
+This module does on initialization:
+- creates an ipset (http://ipset.netfilter.org) called <myset> (hash:ip,port)
+- appends a rule to chain <mychain> that allows <ip,port> addresses in a set <myset> to be forwarded to the container.
+- appends a rule to chain <mychain> that will drop packets going to the docker0 device.
+
+Or in actual commands
+```
+/usr/sbin/ipset create <myset> hash:ip,port family inet6
+/usr/sbin/ip6tables -A <mychain> -o docker0 -m set --match-set <myset> dst,dst -j ACCEPT
+/usr/sbin/ip6tables -A <mychain> -o docker0 -j DROP
+```
+
+When an IPv6 service gets registered:
+- the container <ip,port> will be added to <myset> and access to this port will be allowed.
+- icmpv6 echo request will also be allowed so that you can ping the container
+
+Or in actual commands
+```
+/usr/sbin/ipset add <myset> <ip,proto:port>
+/usr/sbin/ipset add <myset> <ip,icmpv6:128/0>
+```
+
+When the service gets deregistered, the access will be removed.
+
+### Firewalld support
+The module will communicate with firewalld when detected.   
+The default FORWARD_direct chain would be a good chain to use with firewalld
+
+### Prerequisites
+- You need the iptables (v1.4.21+) and ipset (v6.19+) packages
+- ipset and ip6tables are expected to be found in /usr/sbin
+

--- a/modules.go
+++ b/modules.go
@@ -5,4 +5,5 @@ import (
 	_ "github.com/gliderlabs/registrator/consulkv"
 	_ "github.com/gliderlabs/registrator/etcd"
 	_ "github.com/gliderlabs/registrator/skydns2"
+	_ "github.com/gliderlabs/registrator/netfilter"
 )

--- a/netfilter/firewalld.go
+++ b/netfilter/firewalld.go
@@ -1,0 +1,152 @@
+// based on github.com/docker/libnetwork/iptables/firewalld.go
+// apache 2.0 license
+package netfilter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/godbus/dbus"
+)
+
+const (
+	dbusInterface = "org.fedoraproject.FirewallD1"
+	dbusPath      = "/org/fedoraproject/FirewallD1"
+)
+
+// Conn is a connection to firewalld dbus endpoint.
+type Conn struct {
+	sysconn *dbus.Conn
+	sysobj  dbus.BusObject
+	signal  chan *dbus.Signal
+}
+
+var (
+	connection       *Conn
+	firewalldRunning bool      // is Firewalld service running
+	onReloaded       []*func() // callbacks when Firewalld has been reloaded
+)
+
+// FirewalldInit initializes firewalld management code.
+func FirewalldInit() error {
+	var err error
+
+	if connection, err = newConnection(); err != nil {
+		return fmt.Errorf("Failed to connect to D-Bus system bus: %v", err)
+	}
+	if connection != nil {
+		go signalHandler()
+	}
+
+	firewalldRunning = checkRunning()
+	return nil
+}
+
+// New() establishes a connection to the system bus.
+func newConnection() (*Conn, error) {
+	c := new(Conn)
+	if err := c.initConnection(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// Innitialize D-Bus connection.
+func (c *Conn) initConnection() error {
+	var err error
+
+	c.sysconn, err = dbus.SystemBus()
+	if err != nil {
+		return err
+	}
+
+	// This never fails, even if the service is not running atm.
+	c.sysobj = c.sysconn.Object(dbusInterface, dbus.ObjectPath(dbusPath))
+
+	rule := fmt.Sprintf("type='signal',path='%s',interface='%s',sender='%s',member='Reloaded'",
+		dbusPath, dbusInterface, dbusInterface)
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
+
+	rule = fmt.Sprintf("type='signal',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',sender='org.freedesktop.DBus',arg0='%s'",
+		dbusInterface)
+	c.sysconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, rule)
+
+	c.signal = make(chan *dbus.Signal, 10)
+	c.sysconn.Signal(c.signal)
+
+	return nil
+}
+
+func signalHandler() {
+	for signal := range connection.signal {
+		if strings.Contains(signal.Name, "NameOwnerChanged") {
+			firewalldRunning = checkRunning()
+			dbusConnectionChanged(signal.Body)
+		} else if strings.Contains(signal.Name, "Reloaded") {
+			reloaded()
+		}
+	}
+}
+
+func dbusConnectionChanged(args []interface{}) {
+	name := args[0].(string)
+	oldOwner := args[1].(string)
+	newOwner := args[2].(string)
+
+	if name != dbusInterface {
+		return
+	}
+
+	if len(newOwner) > 0 {
+		connectionEstablished()
+	} else if len(oldOwner) > 0 {
+		connectionLost()
+	}
+}
+
+func connectionEstablished() {
+	reloaded()
+}
+
+func connectionLost() {
+	// Doesn't do anything for now. Libvirt also doesn't react to this.
+}
+
+// call all callbacks
+func reloaded() {
+	for _, pf := range onReloaded {
+		(*pf)()
+	}
+}
+
+// OnReloaded add callback
+func OnReloaded(callback func()) {
+	for _, pf := range onReloaded {
+		if pf == &callback {
+			return
+		}
+	}
+	onReloaded = append(onReloaded, &callback)
+}
+
+// Call some remote method to see whether the service is actually running.
+func checkRunning() bool {
+	var zone string
+	var err error
+
+	if connection != nil {
+		err = connection.sysobj.Call(dbusInterface+".getDefaultZone", 0).Store(&zone)
+		return err == nil
+	}
+	return false
+}
+
+// Passthrough method simply passes args through to iptables/ip6tables
+func Passthrough(args []string) ([]byte, error) {
+	var output string
+	if err := connection.sysobj.Call(dbusInterface+".direct.passthrough", 0, "ipv6", args).Store(&output); err != nil {
+		return nil, err
+	}
+	return []byte(output), nil
+}

--- a/netfilter/helpers.go
+++ b/netfilter/helpers.go
@@ -1,0 +1,90 @@
+package netfilter
+
+import (
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+const (
+	ip6tablesPath = "/usr/sbin/ip6tables"
+	ipsetPath     = "/usr/sbin/ipset"
+)
+
+func checkTestError(err error) (bool, error) {
+	switch {
+	case err == nil:
+		return true, nil
+	case err.(*exec.ExitError).Sys().(syscall.WaitStatus).ExitStatus() == 1:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func iptablesRun(ipcmd string) error {
+	args := strings.Fields(ipcmd)
+	if firewalldRunning && !strings.HasPrefix(ipcmd, "-t") {
+		Passthrough(args)
+	} else {
+		cmd := exec.Cmd{Path: ip6tablesPath, Args: append([]string{ip6tablesPath}, args...)}
+		if err := cmd.Run(); err != nil {
+			return err.(*exec.ExitError)
+		}
+	}
+	return nil
+}
+
+func ipsetRun(ipcmd string) error {
+	args := strings.Fields(ipcmd)
+	cmd := exec.Cmd{Path: ipsetPath, Args: append([]string{ipsetPath}, args...)}
+	if err := cmd.Run(); err != nil {
+		return err.(*exec.ExitError)
+	}
+	return nil
+}
+
+func ipsetHost(command string, set string, ip string, proto string, port string) error {
+	cmd := "-! " + command + " " + set + " " + ip + "," + proto + ":" + port
+	err := ipsetRun(cmd)
+	if err != nil {
+		return err
+	}
+	cmd = "-! " + command + " " + set + " " + ip + "," + "icmpv6:128/0"
+	err = ipsetRun(cmd)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func iptablesInit(chain string, set string) error {
+	exists, err := checkTestError(iptablesRun("-t filter -C " + chain + " -o docker0 -m set --match-set " + set + " dst,dst -j ACCEPT --wait"))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		iptablesRun("-A " + chain + " -o docker0 -m set --match-set " + set + " dst,dst -j ACCEPT --wait")
+	}
+	exists, err = checkTestError(iptablesRun("-t filter -C " + chain + " -o docker0 -j DROP --wait"))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		iptablesRun("-A " + chain + " -o docker0 -j DROP --wait")
+	}
+
+	return nil
+}
+
+func ipsetInit(set string) error {
+	err := ipsetRun("-! create " + set + " hash:ip,port family inet6")
+	if err != nil {
+		return err
+	}
+	err = ipsetRun("-! flush " + set)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netfilter/netfilter.go
+++ b/netfilter/netfilter.go
@@ -1,0 +1,62 @@
+package netfilter
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/gliderlabs/registrator/bridge"
+)
+
+func init() {
+	bridge.Register(new(Factory), "netfilter")
+}
+
+type Factory struct{}
+
+func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
+	var chain, set string
+	if uri.Host != "" {
+		chain = uri.Host
+		set = strings.Replace(uri.Path, "/", "", -1)
+	} else {
+		chain = "FORWARD_direct"
+		set = "containerports"
+	}
+	FirewalldInit()
+	if firewalldRunning {
+		OnReloaded(func() { iptablesInit(chain, set) })
+	}
+	ipsetInit(set)
+	iptablesInit(chain, set)
+	return &NetfilterAdapter{Chain: chain, Set: set}
+}
+
+type NetfilterAdapter struct {
+	Chain string
+	Set   string
+}
+
+func (r *NetfilterAdapter) Ping() error {
+	return nil
+}
+
+func (r *NetfilterAdapter) Register(service *bridge.Service) error {
+	if strings.Contains(service.IP, ":") {
+		return ipsetHost("add", r.Set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
+	} else {
+		return nil
+	}
+}
+
+func (r *NetfilterAdapter) Deregister(service *bridge.Service) error {
+	if strings.Contains(service.IP, ":") {
+		return ipsetHost("del", r.Set, service.IP, service.Origin.PortType, strconv.Itoa(service.Port))
+	} else {
+		return nil
+	}
+}
+
+func (r *NetfilterAdapter) Refresh(service *bridge.Service) error {
+	return nil
+}


### PR DESCRIPTION
When using IPv6 containers, the NAT is gone and your container and ports are by default reachable. 
You can use this module to firewall those.

(more documentation in backends.md)

PR #229 must be merged first for this module to be useful
