### PR TITLE
Refactor bridge for better testability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Added
+- bridge.Ping - calls adapter.Ping
 
 ### Removed
 
 ### Changed
 - Upgraded base image to alpine:3.2 and go 1.4
+- bridge.New returns an error instead of calling log.Fatal
+- bridge.New will not attempt to ping an adapter.
 
 ## [v6] - 2015-08-07
 ### Fixed

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"log"
 	"net"
 	"net/url"
@@ -22,28 +23,28 @@ type Bridge struct {
 	config         Config
 }
 
-func New(docker *dockerapi.Client, adapterUri string, config Config) *Bridge {
+func New(docker *dockerapi.Client, adapterUri string, config Config) (*Bridge, error) {
 	uri, err := url.Parse(adapterUri)
 	if err != nil {
-		log.Fatal("Bad adapter URI:", adapterUri)
+		return nil, errors.New("bad adapter uri: " + adapterUri)
 	}
 	factory, found := AdapterFactories.Lookup(uri.Scheme)
 	if !found {
-		log.Fatal("Unrecognized adapter:", adapterUri)
+		return nil, errors.New("unrecognized adapter: " + adapterUri)
 	}
-	adapter := factory.New(uri)
-	err = adapter.Ping()
-	if err != nil {
-		log.Fatalf("%s: %s", uri.Scheme, err)
-	}
+
 	log.Println("Using", uri.Scheme, "adapter:", uri)
 	return &Bridge{
 		docker:         docker,
 		config:         config,
-		registry:       adapter,
+		registry:       factory.New(uri),
 		services:       make(map[string][]*Service),
 		deadContainers: make(map[string]*DeadContainer),
-	}
+	}, nil
+}
+
+func (b *Bridge) Ping() error {
+	return b.registry.Ping()
 }
 
 func (b *Bridge) Add(containerId string) {

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -1,0 +1,23 @@
+package bridge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewError(t *testing.T) {
+	bridge, err := New(nil, "", Config{})
+	assert.Nil(t, bridge)
+	assert.Error(t, err)
+}
+
+func TestNewValid(t *testing.T) {
+	Register(new(fakeFactory), "fake")
+	// Note: the following is valid for New() since it does not
+	// actually connect to docker.
+	bridge, err := New(nil, "fake://", Config{})
+
+	assert.NotNil(t, bridge)
+	assert.NoError(t, err)
+}

--- a/bridge/types_test.go
+++ b/bridge/types_test.go
@@ -1,0 +1,25 @@
+package bridge
+
+import "net/url"
+
+type fakeFactory struct{}
+
+func (f *fakeFactory) New(uri *url.URL) RegistryAdapter {
+
+	return &fakeAdapter{}
+}
+
+type fakeAdapter struct{}
+
+func (f *fakeAdapter) Ping() error {
+	return nil
+}
+func (f *fakeAdapter) Register(service *Service) error {
+	return nil
+}
+func (f *fakeAdapter) Deregister(service *Service) error {
+	return nil
+}
+func (f *fakeAdapter) Refresh(service *Service) error {
+	return nil
+}

--- a/registrator.go
+++ b/registrator.go
@@ -62,7 +62,7 @@ func main() {
 		assert(errors.New("-deregister must be \"always\" or \"on-success\""))
 	}
 
-	b := bridge.New(docker, flag.Arg(0), bridge.Config{
+	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		ForceTags:       *forceTags,
@@ -70,6 +70,9 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 	})
+
+	assert(err)
+	assert(b.Ping())
 
 	// Start event listener before listing containers to avoid missing anything
 	events := make(chan *dockerapi.APIEvents)


### PR DESCRIPTION
- bridge.New no longer attempts to ping an adapter, caller must now use the bridge Ping method
- a few simple tests have been added to the bridge pkg