### PR TITLE
Use exit status to determine if container was killed

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -145,8 +145,6 @@ func main() {
 			go b.Add(msg.ID)
 		case "die":
 			go b.RemoveOnExit(msg.ID)
-		case "stop", "kill":
-			go b.Remove(msg.ID)
 		}
 	}
 


### PR DESCRIPTION
Instead of using the "kill" and "stop" events, this uses the exit status to
check whether the container was terminated via a signal. This will be more
reliable since the "kill" event can also be sent for non-fatal signals such as
SIGHUP.

Fixes #248