### PR TITLE
Revert "fix where providing a SERVICE_NAME for a container with multi…

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -177,7 +177,10 @@ func (b *Bridge) add(containerId string, quiet bool) {
 func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
-	
+	if isgroup {
+		defaultName = defaultName + "-" + port.ExposedPort
+	}
+
 	// not sure about this logic. kind of want to remove it.
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -206,9 +209,6 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.Origin = port
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
-	if isgroup {
-		 service.Name += "-" + port.ExposedPort
-	}
 	var p int
 	if b.config.Internal == true {
 		service.IP = port.ExposedIP


### PR DESCRIPTION
This fix is sub-optimal for many use cases and forces a '-PORT' onto the end of a
service name even if there are already user-supplied unique names for
that service/port combination (e.g. SERVICE_[PORT]_NAME is defined).
Another example is where there are multiple ports, but only one is registered for service discovery (e.g. all but one service/port has its SERVICE_[PORT]_IGNORE flag set).

The solution to overwriting services in the face of multiple ports is
for the user to supply unique names.
An error might be generated if unique names are not provided, but any
auto-generated unique naming scheme like this is not general enough and
causes issues for many use cases.

Forcing an embedding of the port results in ugly dns names for skydns and consul (e.g. myservice-8105.service.consul)