### PR TITLE
Add per container support for the internal and ip flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - bridge.Ping - calls adapter.Ping
+- Added per container support for the internal flag with the registrator:internal environment variable.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - bridge.Ping - calls adapter.Ping
 - Added per container support for the internal flag with the registrator:internal environment variable.
+- Added per container support for the ip flag with the registrator:ip environment variable.
 
 ### Removed
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -151,7 +151,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	}
 
 	for _, port := range ports {
-		if b.config.Internal != true && port.HostPort == "" {
+		if b.isInternal(container) != true && port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			}
@@ -210,7 +210,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		service.Name += "-" + port.ExposedPort
 	}
 	var p int
-	if b.isInternal(port) == true {
+	if b.isInternal(container) == true {
 		service.IP = port.ExposedIP
 		p, _ = strconv.Atoi(port.ExposedPort)
 	} else {
@@ -284,8 +284,7 @@ func (b *Bridge) didExitCleanly(containerId string) bool {
 	return !container.State.Running && container.State.ExitCode == 0
 }
 
-func (b *Bridge) isInternal(port ServicePort) bool {
-	container := port.container
+func (b *Bridge) isInternal(container *dockerapi.Container) bool {
 
 	for _, e := range container.Config.Env {
 		if ok, key, value := parseEnv(e); ok && key == "internal" {

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -295,7 +295,7 @@ func (b *Bridge) extractPort(port ServicePort) (string, int) {
 	container := port.container
 
 	if b.isInternal(container) {
-		p, _ := strconv.Atoi(port.ExposedPort)
+		p, _ = strconv.Atoi(port.ExposedPort)
 		IP = port.ExposedIP
 	} else {
 		p, _ = strconv.Atoi(port.HostPort)

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -292,6 +292,8 @@ func (b *Bridge) extractPort(port ServicePort) (string, int) {
 	var p int
 	var IP string
 
+	container := port.container
+
 	if b.isInternal(container) {
 		p, _ := strconv.Atoi(port.ExposedPort)
 		IP = port.ExposedIP

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -33,7 +33,7 @@ func combineTags(tagParts ...string) []string {
 func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
 	meta := config.Env
 	for k, v := range config.Labels {
-		meta = append(meta, k + "=" + v)
+		meta = append(meta, k+"="+v)
 	}
 	metadata := make(map[string]string)
 	for _, kv := range meta {
@@ -55,6 +55,20 @@ func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
 	return metadata
 }
 
+func parseEnv(e string) (bool, string, string) {
+	parts := strings.SplitN(e, ":", 2)
+	if len(parts) != 2 || parts[0] != "registrator" {
+		return false, "", ""
+	}
+
+	parts = strings.SplitN(parts[1], "=", 2)
+	if len(parts) != 2 {
+		return false, "", ""
+	}
+
+	return true, parts[0], parts[1]
+}
+
 func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
 	var hp, hip, ep, ept string
 	if len(published) > 0 {
@@ -69,7 +83,7 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	if len(exposedPort) == 2 {
 		ept = exposedPort[1]
 	} else {
-		ept = "tcp"  // default
+		ept = "tcp" // default
 	}
 	return ServicePort{
 		HostPort:          hp,

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -51,7 +51,8 @@ be selectively enabled or disabled for individual containers by including
 By default, when registering a service, Registrator will assign the service
 address by attempting to resolve the current hostname. If you would like to
 force the service address to be a specific address, you can specify the `-ip`
-argument.
+argument. The IP can be set selectively per container by including
+`registrator:ip=<ip address>` in the container environment.
 
 For registry backends that support TTL expiry, Registrator can both set and
 refresh service TTLs with `-ttl` and `-ttl-refresh`.

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,7 +44,9 @@ Option                   | Description
 `-resync <seconds>`      | Frequency all services are resynchronized. Default: 0, never
 
 If the `-internal` option is used, Registrator will register the docker0
-internal IP and port instead of the host mapped ones.
+internal IP and port instead of the host mapped ones. This behavior can
+be selectively enabled or disabled for individual containers by including
+`registrator:internal=<true/false>` in the container environment.
 
 By default, when registering a service, Registrator will assign the service
 address by attempting to resolve the current hostname. If you would like to


### PR DESCRIPTION
I ran into a scenario using the docker network overlay where most of the time I need the containers to report their internal ip, except for things that provide services off of our SDN.

This patch allows containers to override the default behavior of the internal/ip application flags by adding to the container environment registrator:internal=<true/false>, registrator:ip=<ip address>.