### PR TITLE
Use ExposedPorts for --net=host

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -179,7 +179,8 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	ports := make(map[string]ServicePort)
 
 	// Extract configured host port mappings, relevant when using --net=host
-	for port, published := range container.HostConfig.PortBindings {
+	for port, _ := range container.Config.ExposedPorts {
+		published := []dockerapi.PortBinding{ {"0.0.0.0", port.Port()}, }
 		ports[string(port)] = servicePort(container, port, published)
 	}
 


### PR DESCRIPTION
Simple change to support the fact that docker no longer fills out mapped ports when run in --net=host mode. This instead simply reads all exposed ports and fills out the relevant service structure, restoring the original functionality.

Fixes #159