### PR TITLE
Include regex

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -134,9 +134,9 @@ func (b *Bridge) add(containerId string, quiet bool) {
 		return
 	}
 
-	match, _ := regexp.MatchString(includeRexEx, container.Name)
+	match, _ := regexp.MatchString(includeRegex, container.Name)
 	if !match {
-		log.Println("Container ", container.Name, " does not match ", includeRexEx)
+		log.Println("Container ", container.Name, " does not match ", includeRegex)
 		return
 	}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -130,6 +131,12 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	container, err := b.docker.InspectContainer(containerId)
 	if err != nil {
 		log.Println("unable to inspect container:", containerId[:12], err)
+		return
+	}
+
+	match, _ := regexp.MatchString(includeRexEx, container.Name)
+	if !match {
+		log.Println("Container ", container.Name, " does not match ", includeRexEx)
 		return
 	}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -48,10 +48,10 @@ func (b *Bridge) Ping() error {
 	return b.registry.Ping()
 }
 
-func (b *Bridge) Add(containerId string) {
+func (b *Bridge) Add(containerId string, includeRegex string) {
 	b.Lock()
 	defer b.Unlock()
-	b.add(containerId, false)
+        b.add(containerId, includeRegex, false)
 }
 
 func (b *Bridge) Remove(containerId string) {
@@ -85,7 +85,7 @@ func (b *Bridge) Refresh() {
 	}
 }
 
-func (b *Bridge) Sync(quiet bool) {
+func (b *Bridge) Sync(includeRegex string, quiet bool) {
 	b.Lock()
 	defer b.Unlock()
 
@@ -104,7 +104,7 @@ func (b *Bridge) Sync(quiet bool) {
 	for _, listing := range containers {
 		services := b.services[listing.ID]
 		if services == nil {
-			b.add(listing.ID, quiet)
+                        b.add(listing.ID, includeRegex, quiet)
 		} else {
 			for _, service := range services {
 				err := b.registry.Register(service)
@@ -116,7 +116,7 @@ func (b *Bridge) Sync(quiet bool) {
 	}
 }
 
-func (b *Bridge) add(containerId string, quiet bool) {
+func (b *Bridge) add(containerId string, includeRegex string, quiet bool) {
 	if d := b.deadContainers[containerId]; d != nil {
 		b.services[containerId] = d.Services
 		delete(b.deadContainers, containerId)

--- a/registrator.go
+++ b/registrator.go
@@ -25,6 +25,7 @@ var resyncInterval = flag.Int("resync", 0, "Frequency with which services are re
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
+var includeRegex = flag.String("include", ".*", "Regex of container names to register.")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {

--- a/registrator.go
+++ b/registrator.go
@@ -103,7 +103,7 @@ func main() {
 	assert(docker.AddEventListener(events))
 	log.Println("Listening for Docker events ...")
 
-	b.Sync(false)
+	b.Sync(*includeRegex, false)
 
 	quit := make(chan struct{})
 
@@ -130,7 +130,7 @@ func main() {
 			for {
 				select {
 				case <-resyncTicker.C:
-					b.Sync(true)
+					b.Sync(*includeRegex, true)
 				case <-quit:
 					resyncTicker.Stop()
 					return
@@ -143,7 +143,7 @@ func main() {
 	for msg := range events {
 		switch msg.Status {
 		case "start":
-			go b.Add(msg.ID)
+			go b.Add(msg.ID, *includeRegex)
 		case "die":
 			go b.RemoveOnExit(msg.ID)
 		case "stop", "kill":


### PR DESCRIPTION
Hey there,
I added the option `-include` to provide a regex (default: `.*`) which has to match the container name in order to register the container.
```
$ /usr/local/bin/registrator -include="reg_.*" -ip dockerhost consul://consul.service.consul:8500
2015/11/03 14:52:57 Starting registrator v7-dev ...
2015/11/03 14:52:57 Forcing host IP to dockerhost
2015/11/03 14:52:57 Using consul adapter: consul://consul.service.consul:8500
2015/11/03 14:52:57 Connecting to backend (0/0)
2015/11/03 14:52:57 consul: current leader  172.17.0.1:8300
2015/11/03 14:52:57 Listening for Docker events ...
2015/11/03 14:52:57 Syncing services on 4 containers
2015/11/03 14:52:57 Container  /base_registrator_1  does not match  reg_.*
2015/11/03 14:52:57 Container  /registry_HyperRegUI_1  does not match  reg_.*
2015/11/03 14:52:57 Container  /base_consul_1  does not match  reg_.*
2015/11/03 14:52:57 Container  /registry_registry_1  does not match  reg_.*
2015/11/03 14:53:17 Container  /furious_bartik  does not match  reg_.*
2015/11/03 14:53:36 added: 743bfee00f87 registrator:reg_www:80
```
An additional `-exclude` might be cool as well.

Cheers
Christian