### PR TITLE
Filtering containerNames

### DIFF
--- a/bridge/types.go
+++ b/bridge/types.go
@@ -54,3 +54,8 @@ type ServicePort struct {
 	ContainerID       string
 	container         *dockerapi.Container
 }
+
+type NameFilter struct {
+	IncludeRegex string
+	ExcludeRegex string
+}

--- a/registrator.go
+++ b/registrator.go
@@ -9,7 +9,7 @@ import (
 
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
-	"github.com/gliderlabs/registrator/bridge"
+	"github.com/qnib/registrator/bridge"
 )
 
 var Version string
@@ -24,7 +24,14 @@ var forceTags = flag.String("tags", "", "Append tags for all registered services
 var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
-var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
+var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts")
+var includeRegex = flag.String("include", ".+", "Regex of container names to register (evaluated after excludeRegex)")
+var excludeRegex = flag.String("exclude", "$.+", "Regex of container names to not register (evaluated before includeRegex).")
+
+//type NameFilter struct {
+//	IncludeRegex string
+//	ExcludeRegex string
+//}
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -47,6 +54,12 @@ func main() {
 	log.Printf("Starting registrator %s ...", Version)
 
 	flag.Parse()
+	
+	nameFilter := bridge.NameFilter{
+		IncludeRegex: *includeRegex,
+		ExcludeRegex: *excludeRegex,
+	}
+	
 
 	if *hostIp != "" {
 		log.Println("Forcing host IP to", *hostIp)
@@ -102,7 +115,7 @@ func main() {
 	assert(docker.AddEventListener(events))
 	log.Println("Listening for Docker events ...")
 
-	b.Sync(false)
+	b.Sync(nameFilter, false)
 
 	quit := make(chan struct{})
 
@@ -129,7 +142,7 @@ func main() {
 			for {
 				select {
 				case <-resyncTicker.C:
-					b.Sync(true)
+					b.Sync(nameFilter, true)
 				case <-quit:
 					resyncTicker.Stop()
 					return
@@ -142,7 +155,7 @@ func main() {
 	for msg := range events {
 		switch msg.Status {
 		case "start":
-			go b.Add(msg.ID)
+			go b.Add(msg.ID, nameFilter)
 		case "die":
 			go b.RemoveOnExit(msg.ID)
 		case "stop", "kill":

--- a/registrator.go
+++ b/registrator.go
@@ -9,7 +9,7 @@ import (
 
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
-	"github.com/qnib/registrator/bridge"
+	"github.com/gliderlabs/registrator/bridge"
 )
 
 var Version string


### PR DESCRIPTION
I refined the PR #283 to use a struct which is able to exclude and include container names.
```
```

```
[root@registrator /]# /usr/local/bin/registrator -exclude="base_" -include="\w+_\w+_\d+" -ip dockerhost consul://consul.service.consul:8500
2015/11/03 16:25:31 Starting registrator v7-dev ...
2015/11/03 16:25:31 Forcing host IP to dockerhost
2015/11/03 16:25:31 Using consul adapter: consul://consul.service.consul:8500
2015/11/03 16:25:31 Connecting to backend (0/0)
2015/11/03 16:25:31 consul: current leader  172.17.0.1:8300
2015/11/03 16:25:31 Listening for Docker events ...
2015/11/03 16:25:31 Syncing services on 4 containers
2015/11/03 16:25:31 Container ' /base_registrator_1 ' matches exclude filter ' base_ ', therefore it's not registered.
2015/11/03 16:25:31 added: 8bd122f046a8 registrator:registry_HyperRegUI_1:8080
2015/11/03 16:25:31 Container ' /base_consul_1 ' matches exclude filter ' base_ ', therefore it's not registered.
2015/11/03 16:25:31 added: 6a6c49701fca registrator:registry_registry_1:5000
2015/11/03 16:25:59 Container ' /reg_www ' doesn't matches include filter ' \w+_\w+_\d+ ', therefore it's not registered.
```