### PR TITLE
IGNORE - Populate internal IP using NetworkSettings.Networks where available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Changed
+- Populate internal IP using NetworkSettings.Networks in docker 1.9+
 - Upgraded base image to alpine:3.2 and go 1.4
 - bridge.New returns an error instead of calling log.Fatal
 - bridge.New will not attempt to ping an adapter.


### PR DESCRIPTION
Docker api 1.21 deprecates NetworkSettings.IPAddress and its value is only
set when using the default docker bridge. To support overlay networks in
docker 1.9, we need to inspect NetworkSettings.Networks.

go-dockerclient has been extended to support this :
https://github.com/fsouza/go-dockerclient/commit/c3e8735e510cf8bc6d439300ff2fc247b1f2867c