### PR TITLE
Support for Docker multi host networking

### DIFF
--- a/bridge/util.go
+++ b/bridge/util.go
@@ -56,7 +56,7 @@ func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
 }
 
 func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
-	var hp, hip, ep, ept string
+	var hp, hip, ep, ept, eip string
 	if len(published) > 0 {
 		hp = published[0].HostPort
 		hip = published[0].HostIP

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -71,11 +71,20 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	} else {
 		ept = "tcp"  // default
 	}
+	
+	// Nir: support docker NetworkSettings
+	eip = container.NetworkSettings.IPAddress
+	if eip == "" {
+		for _, network := range container.NetworkSettings.Networks {
+			eip = network.IPAddress
+		}
+	}
+	
 	return ServicePort{
 		HostPort:          hp,
 		HostIP:            hip,
 		ExposedPort:       ep,
-		ExposedIP:         container.NetworkSettings.IPAddress,
+		ExposedIP:         eip,
 		PortType:          ept,
 		ContainerID:       container.ID,
 		ContainerHostname: container.Config.Hostname,


### PR DESCRIPTION
When using the Docker multi-host networking, IPAddress under NetworkSettings is set to an empty string and the container IP can be retrieved from NetworkSettings.Networks.

At this point it is assumed a single Docker network is associated with the container