### PR TITLE
Add Consul native TCP checks

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -76,8 +76,8 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		check.Script = r.interpolateService(script, service)
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
-	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
-		check.TCP = tcp
+	} else if tcp := service.Attrs["check_tcp"]; tcp == "true" {
+		check.TCP = fmt.Sprintf("%s:%s", service.IP, service.Port)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -76,10 +76,15 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		check.Script = r.interpolateService(script, service)
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
+	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
+		check.TCP = tcp
+		if timeout := service.Attrs["check_timeout"]; timeout != "" {
+			check.Timeout = timeout
+		}
 	} else {
 		return nil
 	}
-	if check.Script != "" || check.HTTP != "" {
+	if check.Script != "" || check.HTTP != "" || check.TCP != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {


### PR DESCRIPTION
Consul 0.6.0 added native TCP checks (https://www.consul.io/docs/agent/checks.html). This will add support to registrator. Just set an environment variable like:

SERVICE_80_CHECK_TCP=true

and the TCP check will be added to the service in Consul.