### PR TITLE
Allow specification of desired docker network to registrator for internal IP registration

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -194,6 +194,14 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	}
 
 	for _, port := range ports {
+        // If internal and can't evaluate the exposed IP (will happen on wrong network), ignore
+        if b.config.Internal == true && port.ExposedIP == "" {
+            if !quiet {
+				log.Println("ignored:", container.ID[:12], "internal IP not found on network", b.config.Network)
+			}
+			continue
+        }
+        
 		if b.config.Internal != true && port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -180,12 +180,12 @@ func (b *Bridge) add(containerId string, quiet bool) {
 
 	// Extract configured host port mappings, relevant when using --net=host
 	for port, published := range container.HostConfig.PortBindings {
-		ports[string(port)] = servicePort(container, port, published)
+		ports[string(port)] = servicePort(container, port, published, b.config.Network)
 	}
 
 	// Extract runtime port mappings, relevant when using --net=bridge
 	for port, published := range container.NetworkSettings.Ports {
-		ports[string(port)] = servicePort(container, port, published)
+		ports[string(port)] = servicePort(container, port, published, b.config.Network)
 	}
 
 	if len(ports) == 0 && !quiet {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -27,6 +27,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+    Network         string
 }
 
 type Service struct {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -55,7 +55,7 @@ func serviceMetaData(config *dockerapi.Config, port string) map[string]string {
 	return metadata
 }
 
-func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
+func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding, network string) ServicePort {
 	var hp, hip, ep, ept string
 	if len(published) > 0 {
 		hp = published[0].HostPort
@@ -71,11 +71,12 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	} else {
 		ept = "tcp"  // default
 	}
+    
 	return ServicePort{
 		HostPort:          hp,
 		HostIP:            hip,
 		ExposedPort:       ep,
-		ExposedIP:         container.NetworkSettings.IPAddress,
+		ExposedIP:         container.NetworkSettings.Networks[network].IPAddress,
 		PortType:          ept,
 		ContainerID:       container.ID,
 		ContainerHostname: container.Config.Hostname,

--- a/registrator.go
+++ b/registrator.go
@@ -27,6 +27,7 @@ var resyncInterval = flag.Int("resync", 0, "Frequency with which services are re
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
+var network = flag.String("network", "bridge", "Network to use for registering exposed IPs")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 
 func getopt(name, def string) string {
@@ -73,6 +74,8 @@ func main() {
 		log.Println("Forcing host IP to", *hostIp)
 	}
 
+	log.Println("Setting network to", *network)
+
 	if (*refreshTtl == 0 && *refreshInterval > 0) || (*refreshTtl > 0 && *refreshInterval == 0) {
 		assert(errors.New("-ttl and -ttl-refresh must be specified together or not at all"))
 	} else if *refreshTtl > 0 && *refreshTtl <= *refreshInterval {
@@ -103,6 +106,7 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
+        Network:         *network,
 	})
 
 	assert(err)


### PR DESCRIPTION
Allow specification of desired docker network to registrator for internal IP registration. Works with new docker 1.9 API.