### PR TITLE
Add support for Consul unix sockets

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -13,7 +13,9 @@ import (
 const DefaultInterval = "10s"
 
 func init() {
-	bridge.Register(new(Factory), "consul")
+	f := new(Factory)
+	bridge.Register(f, "consul")
+	bridge.Register(f, "consul-unix")
 }
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
@@ -26,7 +28,9 @@ type Factory struct{}
 
 func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	config := consulapi.DefaultConfig()
-	if uri.Host != "" {
+	if uri.Scheme == "consul-unix" {
+		config.Address = strings.TrimPrefix(uri.String(), "consul-")
+	} else if uri.Host != "" {
 		config.Address = uri.Host
 	}
 	client, err := consulapi.NewClient(config)

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -5,27 +5,34 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
 )
 
 func init() {
-	bridge.Register(new(Factory), "consulkv")
+	f := new(Factory)
+	bridge.Register(f, "consulkv")
+	bridge.Register(f, "consulkv-unix")
 }
 
 type Factory struct{}
 
 func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	config := consulapi.DefaultConfig()
-	if uri.Host != "" {
+	path := uri.Path
+	if uri.Scheme == "consulkv-unix" {
+		spl := strings.SplitN(uri.Path, ":", 2)
+		config.Address, path = "unix://"+spl[0], spl[1]
+	} else if uri.Host != "" {
 		config.Address = uri.Host
 	}
 	client, err := consulapi.NewClient(config)
 	if err != nil {
 		log.Fatal("consulkv: ", uri.Scheme)
 	}
-	return &ConsulKVAdapter{client: client, path: uri.Path}
+	return &ConsulKVAdapter{client: client, path: path}
 }
 
 type ConsulKVAdapter struct {
@@ -46,9 +53,11 @@ func (r *ConsulKVAdapter) Ping() error {
 }
 
 func (r *ConsulKVAdapter) Register(service *bridge.Service) error {
+	log.Println("Register")
 	path := r.path[1:] + "/" + service.Name + "/" + service.ID
 	port := strconv.Itoa(service.Port)
 	addr := net.JoinHostPort(service.IP, port)
+	log.Printf("path: %s", path)
 	_, err := r.client.KV().Put(&consulapi.KVPair{Key: path, Value: []byte(addr)}, nil)
 	if err != nil {
 		log.Println("consulkv: failed to register service:", err)

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -9,6 +9,7 @@ See also [Contributing Backends](../dev/backends.md).
 ## Consul
 
 	consul://<address>:<port>
+	consul-unix://<filepath>
 
 Consul is the recommended registry since it specifically models services for
 service discovery with health checks.
@@ -63,6 +64,7 @@ SERVICE_CHECK_TTL=30s
 ## Consul KV
 
 	consulkv://<address>:<port>/<prefix>
+	consulkv-unix://<filepath>:/<prefix>
 
 This is a separate backend to use Consul's key-value store instead of its native
 service catalog. This behaves more like etcd since it has similar semantics, but


### PR DESCRIPTION
This PR adds support for socket-based Consul connections. This would be especially convenient in overlay network environments where it could be difficult to tell whether you're talking to the _local_ Consul node or a remote one. It'd also be useful in Docker-in-Docker use cases like RancherOS where you may want to run Registrator in `system-docker` so that it's available immediately on boot. 

I piggy-backed onto the existing `consul` and `consulkv` Factories by adding a `-unix` suffix to the schemes and then doing a little additional parsing in `New()`.

The service backend works as expected, but the KV backend looks a little funky. Since we can't rely on slashes for the path (and thus the KV prefix), there's an extra colon to delimit the prefix i.e. `consulkv-unix:///var/run/consul.sock:/base/key`.

Commits are squashed and docs are added, let me know what you think!