### PR TITLE
Support for Docker checks with Consul

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -74,6 +74,13 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
 	} else if script := service.Attrs["check_script"]; script != "" {
 		check.Script = r.interpolateService(script, service)
+	} else if script := service.Attrs["check_docker_script"]; script != "" {
+		check.Script = r.interpolateService(script, service)
+		check.DockerContainerID = service.Origin.ContainerID
+		if shell := service.Attrs["check_docker_shell"]; shell != "" {
+			check.Shell = shell
+		}
+
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else {


### PR DESCRIPTION
Adds support for Docker checks as described in [Consul docs](https://www.consul.io/docs/agent/checks.html). This runs the check command inside the container. 

I've tested this with Consul 0.6 (note that consul interprets the check command's exit code 0 as success, 1 as warning, 2 as critical):

```
host$ docker run -it --rm -e SERVICE_NAME=test1 -e SERVICE_CHECK_DOCKER_SCRIPT="test -f /tmp/x || exit 2" -e SERVICE_CHECK_DOCKER_SHELL=/bin/sh -p 10011:1234 alpine sh

host$ consul-cli health-service test1
...
      {
        "Node": "ip-10-234-180-74.ec2.internal",
        "CheckID": "service:ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "Name": "Service 'test1' check",
        "Status": "critical",
        "Notes": "",
        "Output": "",
        "ServiceID": "ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "ServiceName": "test1"
      }
...

container# touch /tmp/x

host$ consul-cli health-service test1
...
  {
        "Node": "ip-10-234-180-74.ec2.internal",
        "CheckID": "service:ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "Name": "Service 'test1' check",
        "Status": "passing",
        "Notes": "",
        "Output": "",
        "ServiceID": "ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "ServiceName": "test1"
      }
...

host$ dig test1.service.consul SRV
...
;; ANSWER SECTION:
test1.service.consul.	0	IN	SRV	1 1 10011 ip-10-234-180-74.ec2.internal.node.us-east-1.consul.
...
container# rm /tmp/x

host$ dig test1.service.consul SRV
# nothing

host$ consul-cli health-service test1
...
      {
        "Node": "ip-10-234-180-74.ec2.internal",
        "CheckID": "service:ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "Name": "Service 'test1' check",
        "Status": "critical",
        "Notes": "",
        "Output": "",
        "ServiceID": "ip-10-234-180-74.ec2.internal:grave_noyce:1234",
        "ServiceName": "test1"
      }
...

```