### PR TITLE
Remove stale services from registrator

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -138,7 +138,7 @@ func (b *Bridge) Sync(quiet bool) {
 			// This is a container that does not exist
 			if !found {
 				log.Printf("stale: Removing service %s because it does not exist", listingId)
-				go b.Remove(listingId)
+				go b.RemoveOnExit(listingId)
 			}
 		}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -123,11 +123,9 @@ func (b *Bridge) Sync(quiet bool) {
 		log.Println("Listing non-exited containers")
 		filters := map[string][]string{"status": {"created", "restarting", "running", "paused"}}
 		nonExitedContainers, err := b.docker.ListContainers(dockerapi.ListContainersOptions{Filters: filters})
-		if err != nil && quiet {
-			log.Println("error listing nonExitedContainers, skipping sync")
+		if err != nil {
+			log.Println("error listing nonExitedContainers, skipping sync", err)
 			return
-		} else if err != nil && !quiet {
-			log.Fatal(err)
 		}
 		for listingId, _ := range b.services {
 			found := false


### PR DESCRIPTION
This PR removes `stale` services from the registrator's memory. A `stale` service is a service that is present in the memory but its corresponding container is not actually running on the host (or has exited).

This issue has been observed when registrator at times misses out on capturing some docker *(die)* events. Hence this could lead to stale services which also get propagated into the registry backends.

My solution here is to add logic during cleanup to check whether the services in memory actually have their corresponding container running on the host. If not, then remove it.

I have tested this on my end and it seems to work just fine!

Relates to: https://github.com/gliderlabs/registrator/issues/325