### PR TITLE
Fix missing ServiceAddress when using networks from docker-compose (overlay)

### DIFF
--- a/bridge/util.go
+++ b/bridge/util.go
@@ -61,7 +61,7 @@ func serviceMetaData(config *dockerapi.Config, port string) (map[string]string, 
 }
 
 func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
-	var hp, hip, ep, ept, eip string
+	var hp, hip, ep, ept, eip, nm string
 	if len(published) > 0 {
 		hp = published[0].HostPort
 		hip = published[0].HostIP
@@ -69,6 +69,15 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	if hip == "" {
 		hip = "0.0.0.0"
 	}
+
+	//for overlay networks
+	//detect if container use overlay network, than set HostIP into NetworkSettings.Network[string].IPAddress
+	//better to use registrator with -internal flag
+	nm = container.HostConfig.NetworkMode
+	if nm != "bridge" || nm != "default" || nm != "host" {
+		hip = container.NetworkSettings.Networks[nm].IPAddress
+	}
+
 	exposedPort := strings.Split(string(port), "/")
 	ep = exposedPort[0]
 	if len(exposedPort) == 2 {


### PR DESCRIPTION
  add support hostip for overlay network