### PR TITLE
FIX: Consul interpolateService do not work with -internal

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/gliderlabs/registrator/bridge"
@@ -19,8 +20,8 @@ func init() {
 }
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
-	withIp := strings.Replace(script, "$SERVICE_IP", service.Origin.HostIP, -1)
-	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
+	withIp := strings.Replace(script, "$SERVICE_IP", service.IP, -1)
+	withPort := strings.Replace(withIp, "$SERVICE_PORT", strconv.Itoa(service.Port), -1)
 	return withPort
 }
 


### PR DESCRIPTION
Hi, I've noticed that Consul interpolateService do not work.

I think that it should be related to the fact that I'm using it with the `-internal` flag.

Here is a docker-compose example:

```yaml
version: '2'
services:
  registrator:
    build: .
    command: -internal -resync 60 consul://consul:8500
    volumes:
      - /var/run/docker.sock:/tmp/docker.sock
    links:
     - consul
  consul:
    image: gliderlabs/consul-server:0.6
    command: -bootstrap
    ports:
      - 8500:8500
  web:
    image: nginx:1.9
    environment:
      SERVICE_80_NAME: http
      SERVICE_443_NAME_IGNORE: "true"
      SERVICE_80_check_script: "echo 'GET / HTTP/1.0' | nc $$SERVICE_IP $$SERVICE_PORT"
    depends_on:
      - registrator
```

In this case registrator will record the following check `echo 'GET / HTTP/1.0' | nc 172.17.0.4` without the port

```$docker exec registrator_consul_1 sh -c 'cat /data/checks/*'```

```json
{ "Check" : { "CheckID" : "service:217ce4f1b849:registrator_web_1:80",
      "CreateIndex" : 0,
      "ModifyIndex" : 0,
      "Name" : "Service 'http' check",
      "Node" : "0a8aaed81458",
      "Notes" : "",
      "Output" : "",
      "ServiceID" : "217ce4f1b849:registrator_web_1:80",
      "ServiceName" : "http",
      "Status" : "critical"
    },
  "ChkType" : { "DockerContainerID" : "",
      "HTTP" : "",
      "Interval" : 10000000000,
      "Notes" : "",
      "Script" : "echo 'GET / HTTP/1.0' | nc 172.18.0.4 ",
      "Shell" : "",
      "Status" : "",
      "TCP" : "",
      "TTL" : 0,
      "Timeout" : 0
    },
  "Token" : ""
}
```
