### PR TITLE
removed check_cmd health check

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -74,8 +74,6 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}
-	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
-		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
 	} else if script := service.Attrs["check_script"]; script != "" {
 		check.Script = r.interpolateService(script, service)
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {


### PR DESCRIPTION
as it is no longer available in the registrator according to Jeff Lindsay in https://github.com/gliderlabs/docker-consul/issues/106