### PR TITLE
adding TLS support for consul backend

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -15,8 +15,8 @@ const DefaultInterval = "10s"
 
 func init() {
 	f := new(Factory)
-	bridge.Register(f, "consul-tls")
 	bridge.Register(f, "consul")
+	bridge.Register(f, "consul-tls")
 	bridge.Register(f, "consul-unix")
 }
 

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -5,15 +5,17 @@ import (
 	"log"
 	"net/url"
 	"strings"
-
+	"os"
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 const DefaultInterval = "10s"
 
 func init() {
 	f := new(Factory)
+	bridge.Register(f, "consul-tls")
 	bridge.Register(f, "consul")
 	bridge.Register(f, "consul-unix")
 }
@@ -30,6 +32,23 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	config := consulapi.DefaultConfig()
 	if uri.Scheme == "consul-unix" {
 		config.Address = strings.TrimPrefix(uri.String(), "consul-")
+	} else if uri.Scheme == "consul-tls" {
+	        tlsConfigDesc := &consulapi.TLSConfig {
+			  Address: uri.Host,
+			  CAFile: os.Getenv("CONSUL_CACERT"),
+  			  CertFile: os.Getenv("CONSUL_TLSCERT"),
+  			  KeyFile: os.Getenv("CONSUL_TLSKEY"),
+			  InsecureSkipVerify: false,
+		}
+		tlsConfig, err := consulapi.SetupTLSConfig(tlsConfigDesc)
+		if err != nil {
+		   log.Fatal("Cannot set up Consul TLSConfig", err)
+		}
+		config.Scheme = "https"
+		transport := cleanhttp.DefaultPooledTransport()
+		transport.TLSClientConfig = tlsConfig
+		config.HttpClient.Transport = transport
+		config.Address = uri.Host
 	} else if uri.Host != "" {
 		config.Address = uri.Host
 	}

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -10,6 +10,7 @@ See also [Contributing Backends](../dev/backends.md).
 
 	consul://<address>:<port>
 	consul-unix://<filepath>
+	consul-tls://<address>:<port>
 
 Consul is the recommended registry since it specifically models services for
 service discovery with health checks.
@@ -17,6 +18,11 @@ service discovery with health checks.
 If no address and port is specified, it will default to `127.0.0.1:8500`.
 
 Consul supports tags but no arbitrary service attributes.
+
+When using the `consul-tls` scheme, registrator communicates with Consul through TLS. You must set the following environment variables:
+ * `CONSUL_CACERT` : CA file location
+ * `CONSUL_TLSCERT` : Certificate file location
+ * `CONSUL_TLSKEY` : Key location
 
 ### Consul HTTP Check
 


### PR DESCRIPTION
 - Adding a `consul-tls` backend scheme. It means that you want to use a CA file, CERT file, and KEY file to access consul TLS backend.
- Run registrator the following way:
```
docker run -d --name=registrator --net=host  -v /var/run/docker.sock:/tmp/docker.sock -v /etc/certificates/:/etc/certificates/ -e CONSUL_CACERT=/etc/certificates/docker-ca.crt -e CONSUL_TLSCERT=/etc/certificates/consul-client.crt -e CONSUL_TLSKEY=/etc/certificates/consul-client.key cyprien/registrator consul-tls://srv-consul.local:8543
```