### PR TITLE
Add container hostname to tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Support hostip for overlay network
 - Cleanup dangling services
 - Startup backend service connection retry
+- Support for adding container hostname to service tag
 
 ### Removed
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -317,6 +317,12 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 			mapDefault(metadata, "tags", ""), b.config.ForceTags)
 	}
 
+
+	if b.config.HostnameTag {
+		// add hostname to tags
+		service.Tags = append(service.Tags, container.Config.Hostname)
+	}
+
 	id := mapDefault(metadata, "id", "")
 	if id != "" {
 		service.ID = id

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -28,6 +28,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+	HostnameTag	bool
 }
 
 type Service struct {

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,6 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
+`-hostname-tag`                  | v7    | Add container hostname to tags while registering service
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.

--- a/registrator.go
+++ b/registrator.go
@@ -29,6 +29,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var hostnameTag = flag.Bool("hostname-tag", false, "Append container hostname to tags")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -105,6 +106,7 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
+		HostnameTag:     *hostnameTag,
 	})
 
 	assert(err)


### PR DESCRIPTION
This PR support for adding container hostname to registered service.

It can be useful for discovering external address and external port mapping from container.

Consul api support only tag for searching registered service, so when we have many container instance it is not possible to connect service with specific container.

Now we can run inside container:

```
curl "http://consul.address//v1/catalog/service/<service>?tag=$HOSTNAME"
```

All required data we can simply deliver to container.
