### PR TITLE
feat(consul,service_tags): Support escaped comma

### DIFF
--- a/bridge/types_test.go
+++ b/bridge/types_test.go
@@ -23,3 +23,6 @@ func (f *fakeAdapter) Deregister(service *Service) error {
 func (f *fakeAdapter) Refresh(service *Service) error {
 	return nil
 }
+func (f *fakeAdapter) Services() ([]*Service, error) {
+	return nil, nil
+}

--- a/bridge/util_test.go
+++ b/bridge/util_test.go
@@ -1,51 +1,51 @@
 package bridge
 
 import (
-	"testing"
 	"sort"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEscapedComma(t *testing.T) {
 	cases := []struct {
-		Tag	 string
+		Tag      string
 		Expected []string
 	}{
 		{
-			Tag: "",
+			Tag:      "",
 			Expected: []string{},
 		},
 		{
-			Tag: "foobar",
+			Tag:      "foobar",
 			Expected: []string{"foobar"},
 		},
 		{
-			Tag: "foo,bar",
+			Tag:      "foo,bar",
 			Expected: []string{"foo", "bar"},
 		},
 		{
-			Tag: "foo\\,bar",
+			Tag:      "foo\\,bar",
 			Expected: []string{"foo,bar"},
 		},
 		{
-			Tag: "foo,bar\\,baz",
+			Tag:      "foo,bar\\,baz",
 			Expected: []string{"foo", "bar,baz"},
 		},
 		{
-			Tag: "\\,foobar\\,",
+			Tag:      "\\,foobar\\,",
 			Expected: []string{",foobar,"},
 		},
 		{
-			Tag: ",,,,foo,,,bar,,,",
+			Tag:      ",,,,foo,,,bar,,,",
 			Expected: []string{"foo", "bar"},
 		},
 		{
-			Tag: ",,,,",
+			Tag:      ",,,,",
 			Expected: []string{},
 		},
 		{
-			Tag: ",,\\,,",
+			Tag:      ",,\\,,",
 			Expected: []string{","},
 		},
 	}

--- a/bridge/util_test.go
+++ b/bridge/util_test.go
@@ -1,0 +1,59 @@
+package bridge
+
+import (
+	"testing"
+	"sort"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapedComma(t *testing.T) {
+	cases := []struct {
+		Tag	 string
+		Expected []string
+	}{
+		{
+			Tag: "",
+			Expected: []string{},
+		},
+		{
+			Tag: "foobar",
+			Expected: []string{"foobar"},
+		},
+		{
+			Tag: "foo,bar",
+			Expected: []string{"foo", "bar"},
+		},
+		{
+			Tag: "foo\\,bar",
+			Expected: []string{"foo,bar"},
+		},
+		{
+			Tag: "foo,bar\\,baz",
+			Expected: []string{"foo", "bar,baz"},
+		},
+		{
+			Tag: "\\,foobar\\,",
+			Expected: []string{",foobar,"},
+		},
+		{
+			Tag: ",,,,foo,,,bar,,,",
+			Expected: []string{"foo", "bar"},
+		},
+		{
+			Tag: ",,,,",
+			Expected: []string{},
+		},
+		{
+			Tag: ",,\\,,",
+			Expected: []string{","},
+		},
+	}
+
+	for _, c := range cases {
+		results := recParseEscapedComma(c.Tag)
+		sort.Strings(c.Expected)
+		sort.Strings(results)
+		assert.EqualValues(t, c.Expected, results)
+	}
+}

--- a/docs/user/services.md
+++ b/docs/user/services.md
@@ -166,6 +166,13 @@ Results in `Service`:
 
 Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use.
 
+The comma can be escaped by adding a backslash, such as the following example:
+
+    $ docker run -d --name redis.0 -p 10000:6379 \
+        -e "SERVICE_NAME=db" \
+        -e "SERVICE_TAGS=/(;\\,:-_)/" \
+        -e "SERVICE_REGION=us2" progrium/redis
+
 ### Multiple services with defaults
 
 	$ docker run -d --name nginx.0 -p 4443:443 -p 8000:80 progrium/nginx


### PR DESCRIPTION
#390

Example: 

```
docker run -d \
      -p 4242:4242 \
      -e 'SERVICE_4242_TAGS=traefik.frontend.rule=Host: www.example.com\, Path: /api,traefik.enable=true' \
      company/service
```

Create only 2 tags into consul:
- `traefik.frontend.rule=Host: www.example.com, Path: /api`
- `traefik.enable=true`
