### PR TITLE
Add '-deregister-on-stop' option

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -25,6 +25,7 @@ var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
 var resyncInterval = flag.Int("resync", 0, "Frequency with which services are resynchronized")
 var deregister = flag.String("deregister", "always", "Deregister exited services \"always\" or \"on-success\"")
+var deregisterOnStop = flag.Bool("deregister-on-stop", false, "Deregister when container stopped versus once it dies")
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
@@ -172,6 +173,10 @@ func main() {
 			go b.Add(msg.ID)
 		case "die":
 			go b.RemoveOnExit(msg.ID)
+		case "kill":
+			if *deregisterOnStop {
+				go b.RemoveOnExit(msg.ID)
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently registrator deregisters the service once the container dies, but in some cases that might be too late. The -deregister-on-stop option tells registrator to deregister the service once docker receives either the stop or kill commands, but before the container actually dies.

This gives the service in the container a chance to clean up after itself after receiving a SIGTERM, without the chance that it will receive any new requests before it actually dies.

Note that I think this is probably a bug in the Docker events documentation, and that the intended behavior of registrator is to deregister the service as soon as Docker receives the instruction to stop the container. This would be the "kill" event, not the "die" event, which is the opposite of what [the documentation](https://docs.docker.com/engine/reference/api/images/event_state.png) says.

If my change does bring registrator inline with the intended behavior, then it might be better to make it the default behavior, and not guard it behind a flag. I only added the flag to keep this change backwards compatible.