### PR TITLE
Fixing port issue with service name

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -193,17 +193,17 @@ func (b *Bridge) add(containerId string, quiet bool) {
 		return
 	}
 
-	exposedPorts := 0
+	publishedPorts := 0
 	for _, port := range ports {
 		if b.config.Internal != true && port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			} else {
-				exposedPorts += 1
+				publishedPorts += 1
 			}
 			continue
 		}
-		service := b.newService(port, exposedPorts > 1)
+		service := b.newService(port, publishedPorts > 1)
 		if service == nil {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "service on port", port.ExposedPort)

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -193,14 +193,17 @@ func (b *Bridge) add(containerId string, quiet bool) {
 		return
 	}
 
+	exposedPorts := 0
 	for _, port := range ports {
 		if b.config.Internal != true && port.HostPort == "" {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
+			} else {
+				exposedPorts += 1
 			}
 			continue
 		}
-		service := b.newService(port, len(ports) > 1)
+		service := b.newService(port, exposedPorts > 1)
 		if service == nil {
 			if !quiet {
 				log.Println("ignored:", container.ID[:12], "service on port", port.ExposedPort)


### PR DESCRIPTION
- Adding exposedPorts variable to help identify services that are
grouped to expose multiple ports
- Removed len(ports) check and replaced with exposedPorts to properly
identify grouped ports

Signed-off-by: DJ Enriquez <dj.enriquez@infospace.com>