### PR TITLE
Add consul initial check status to service attributes

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -69,6 +69,9 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
 	check := new(consulapi.AgentServiceCheck)
+	if status := service.Attrs["check_initial_status"]; status != "" {
+		check.Status = status
+	}
 	if path := service.Attrs["check_http"]; path != "" {
 		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -73,6 +73,14 @@ healthy.
 SERVICE_CHECK_TTL=30s
 ```
 
+### Consul Initial Health Check Status
+
+By default when a service is registered against Consul, the state is set to "critical". You can specify the initial health check status.
+
+```bash
+SERVICE_CHECK_INITIAL_STATUS=passing
+```
+
 ## Consul KV
 
 	consulkv://<address>:<port>/<prefix>


### PR DESCRIPTION
This allows to specify initial consul health check status:
`docker run -e "SERVICE_CHECK_INITIAL_STATUS=passing" image`

I know this is a duplicate of #343, but I need this ASAP.