### PR TITLE
fix service ip and port in consul interpolateService

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"strconv"
 	"os"
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
@@ -21,8 +22,8 @@ func init() {
 }
 
 func (r *ConsulAdapter) interpolateService(script string, service *bridge.Service) string {
-	withIp := strings.Replace(script, "$SERVICE_IP", service.Origin.HostIP, -1)
-	withPort := strings.Replace(withIp, "$SERVICE_PORT", service.Origin.HostPort, -1)
+	withIp := strings.Replace(script, "$SERVICE_IP", service.IP, -1)
+	withPort := strings.Replace(withIp, "$SERVICE_PORT", strconv.Itoa(service.Port), -1)
 	return withPort
 }
 


### PR DESCRIPTION
If you use the flag "-internal" is substituted not a valid port to $SERVICE_CHECK_SCRIPT.
Please view and accept the changes, they solve this problem.

> SERVICE_CHECK_SCRIPT=nc $SERVICE_IP $SERVICE_PORT | grep OK
