### PR TITLE
added KILL event for removing container from registry;

### DIFF
--- a/registrator.go
+++ b/registrator.go
@@ -170,8 +170,7 @@ func main() {
 		switch msg.Status {
 		case "start":
 			go b.Add(msg.ID)
-		case "kill":
-		case "die":
+		case "kill", "die":
 			go b.RemoveOnExit(msg.ID)
 		}
 	}

--- a/registrator.go
+++ b/registrator.go
@@ -170,6 +170,7 @@ func main() {
 		switch msg.Status {
 		case "start":
 			go b.Add(msg.ID)
+		case "kill":
 		case "die":
 			go b.RemoveOnExit(msg.ID)
 		}


### PR DESCRIPTION
see https://github.com/docker/docker/issues/15438 for details
`kill` event comes before `die` event, though during graceful shutdown, service is treated as alive, while during shutdown period service should be treated as gone to not accept any more connections
