### PR TITLE
docker host identification improvement and swarm mode support

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -3,9 +3,7 @@ package bridge
 import (
 	"errors"
 	"log"
-//	"net"
 	"net/url"
-//	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -250,18 +248,6 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
 
-	// not sure about this logic. kind of want to remove it.
-	//hostname := Hostname
-	//if hostname == "" {
-	//	hostname = port.HostIP
-	//}
-	//if port.HostIP == "0.0.0.0" {
-	//	ip, err := net.ResolveIPAddr("ip", hostname)
-	//	if err == nil {
-	//		port.HostIP = ip.String()
-	//	}
-	//}
-
 	if b.config.HostIp != "" {
 		port.HostIP = b.config.HostIp
 	}
@@ -371,11 +357,3 @@ func (b *Bridge) shouldRemove(containerId string) bool {
 	}
 	return false
 }
-
-//var Hostname string
-//
-//func init() {
-//	// It's ok for Hostname to ultimately be an empty string
-//	// An empty string will fall back to trying to make a best guess
-//	Hostname, _ = os.Hostname()
-//}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -399,7 +399,7 @@ func (b *Bridge) registerSwarmVipService(serviceName string, inside bool, vip st
 	}
 	// tag it for convenience
 	if protocol != swarm.PortConfigProtocolTCP {
-		svcReg.Tags = combineTags(tag, b.config.ForceTags, protocol)
+		svcReg.Tags = combineTags(tag, b.config.ForceTags, string(protocol))
 	} else {
 		svcReg.Tags = combineTags(tag, b.config.ForceTags)
 	}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -3,9 +3,9 @@ package bridge
 import (
 	"errors"
 	"log"
-	"net"
+//	"net"
 	"net/url"
-	"os"
+//	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -157,7 +157,7 @@ func (b *Bridge) Sync(quiet bool) {
 				continue
 			}
 			serviceHostname := matches[1]
-			if serviceHostname != Hostname {
+			if serviceHostname != b.config.NodeId { // use node id as reference instead of hostname
 				// ignore because registered on a different host
 				continue
 			}
@@ -251,16 +251,16 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
 
 	// not sure about this logic. kind of want to remove it.
-	hostname := Hostname
-	if hostname == "" {
-		hostname = port.HostIP
-	}
-	if port.HostIP == "0.0.0.0" {
-		ip, err := net.ResolveIPAddr("ip", hostname)
-		if err == nil {
-			port.HostIP = ip.String()
-		}
-	}
+	//hostname := Hostname
+	//if hostname == "" {
+	//	hostname = port.HostIP
+	//}
+	//if port.HostIP == "0.0.0.0" {
+	//	ip, err := net.ResolveIPAddr("ip", hostname)
+	//	if err == nil {
+	//		port.HostIP = ip.String()
+	//	}
+	//}
 
 	if b.config.HostIp != "" {
 		port.HostIP = b.config.HostIp
@@ -275,7 +275,8 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 
 	service := new(Service)
 	service.Origin = port
-	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
+	// use node id, which is more reliable
+	service.ID = b.config.NodeId + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
 	if isgroup && !metadataFromPort["name"] {
 		service.Name += "-" + port.ExposedPort
@@ -371,10 +372,10 @@ func (b *Bridge) shouldRemove(containerId string) bool {
 	return false
 }
 
-var Hostname string
-
-func init() {
-	// It's ok for Hostname to ultimately be an empty string
-	// An empty string will fall back to trying to make a best guess
-	Hostname, _ = os.Hostname()
-}
+//var Hostname string
+//
+//func init() {
+//	// It's ok for Hostname to ultimately be an empty string
+//	// An empty string will fall back to trying to make a best guess
+//	Hostname, _ = os.Hostname()
+//}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -20,6 +20,7 @@ type RegistryAdapter interface {
 }
 
 type Config struct {
+	NodeId          string
 	HostIp          string
 	Internal        bool
 	ForceTags       string

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -92,7 +92,7 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 		for name, network := range container.NetworkSettings.Networks {
 			// if in swarm mode and network name is ingress,
 			// no point to publish service with ingress network IP address
-			if _, ok := container.Config.Labels["com.docker.swarm.service.name"]; ok && name != "ingress" {
+			if _, ok := container.Config.Labels["com.docker.swarm.service.name"]; !(ok && name == "ingress") {
 				eip = network.IPAddress
 			}
 		}

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -89,8 +89,12 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 	// Nir: support docker NetworkSettings
 	eip = container.NetworkSettings.IPAddress
 	if eip == "" {
-		for _, network := range container.NetworkSettings.Networks {
-			eip = network.IPAddress
+		for name, network := range container.NetworkSettings.Networks {
+			// if in swarm mode and network name is ingress,
+			// no point to publish service with ingress network IP address
+			if _, ok := container.Config.Labels["com.docker.swarm.service.name"]; ok && name != "ingress" {
+				eip = network.IPAddress
+			}
 		}
 	}
 

--- a/registrator.go
+++ b/registrator.go
@@ -101,9 +101,9 @@ func main() {
 	assert(err)
 
 	nodeId := new(string)
+	// docker host name normally is hostname
+	*nodeId = dockerInfo.Name
 	if dockerInfo.Swarm.LocalNodeState != swarm.LocalNodeStateInactive {
-		// swarm mode identifies each node uniquely
-		*nodeId = dockerInfo.Swarm.NodeID
 		if *hostIp == "" {
 			// in case of swarm mode, docker host has information about ip
 			// although it won't be always useful, we can use it if not provided by user
@@ -111,8 +111,6 @@ func main() {
 		}
 		log.Printf("Docker host in Swarm Mode: %s (%s)", *nodeId, *hostIp)
 	} else {
-		// docker host name normally is hostname
-		*nodeId = dockerInfo.Name
 		log.Printf("Docker host: %s (%s)", *nodeId, *hostIp)
 	}
 

--- a/registrator.go
+++ b/registrator.go
@@ -12,6 +12,7 @@ import (
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
 	"github.com/gliderlabs/registrator/bridge"
+	"github.com/docker/engine-api/types/swarm"
 )
 
 var Version string
@@ -95,7 +96,28 @@ func main() {
 		assert(errors.New("-deregister must be \"always\" or \"on-success\""))
 	}
 
+	// use docker info to determine node id that will be used as prefix to service id
+	dockerInfo, err := docker.Info()
+	assert(err)
+
+	nodeId := new(string)
+	if dockerInfo.Swarm.LocalNodeState != swarm.LocalNodeStateInactive {
+		// swarm mode identifies each node uniquely
+		*nodeId = dockerInfo.Swarm.NodeID
+		if *hostIp == "" {
+			// in case of swarm mode, docker host has information about ip
+			// although it won't be always useful, we can use it if not provided by user
+			*hostIp = dockerInfo.Swarm.NodeAddr
+		}
+		log.Printf("Docker host in Swarm Mode: %s (%s)", *nodeId, *hostIp)
+	} else {
+		// docker host name normally is hostname
+		*nodeId = dockerInfo.Name
+		log.Printf("Docker host: %s (%s)", *nodeId, *hostIp)
+	}
+
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
+		NodeId:          *nodeId,
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		ForceTags:       *forceTags,


### PR DESCRIPTION
First two commits addresses improvement in #475. Since contents of ServiceID changes, users has to make sure that old services match the new pattern, other wise old services has to be re-registered. This improvement simply uses docker info as suggested in #475 to fetch docker node name, which is commonly hostname. Thus there is no need to use registrator container's hostname or attach registrator to host network.

Third commit adds support of swarm node. Nothing breaks by the way. In addition to normal per container service registration adds support of registering docker swarm mode VIPs. Also populates service name from swarm service name, if not specified explicitly in SERVICE_X_NAME. In previous commits, node id in swarm mode was assigned to swarm node id, which is not very useful, as users most likely will know their host names, rather that node id in swarm cluster.
