### PR TITLE
Adds 'useIpFromLabel' parameter

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -252,6 +252,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		service.Name += "-" + port.ExposedPort
 	}
 	var p int
+
 	if b.config.Internal == true {
 		service.IP = port.ExposedIP
 		p, _ = strconv.Atoi(port.ExposedPort)
@@ -260,6 +261,21 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		p, _ = strconv.Atoi(port.HostPort)
 	}
 	service.Port = p
+
+	//TODO: Add config.UseRancherContainerIP to config.... somehow
+	//if b.config.UseRancherContainerIP == true {
+		containerIp := container.Config.Labels["io.rancher.container.ip"]
+		if containerIp != "" {
+			slashIndex := strings.LastIndex(containerIp, "/")
+			if slashIndex > -1 {
+				service.IP = containerIp[:slashIndex]
+			} else {
+				service.IP = containerIp
+			}
+			//log.Println("b.config.UseRancherContainerIP=" + b.config.UseRancherContainerIP + ", using Rancher container IP " + service.IP)
+			log.Println("using Rancher container IP " + service.IP);
+		}
+	//}
 
 	if port.PortType == "udp" {
 		service.Tags = combineTags(

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -291,8 +291,8 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 	service.Port = p
 
-	if b.config.UseRancherContainerIP == true {
-		containerIp := container.Config.Labels["io.rancher.container.ip"]
+	if b.config.UseIpFromLabel != "" {
+		containerIp := container.Config.Labels[b.config.UseIpFromLabel]
 		if containerIp != "" {
 			slashIndex := strings.LastIndex(containerIp, "/")
 			if slashIndex > -1 {
@@ -300,7 +300,11 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 			} else {
 				service.IP = containerIp
 			}
-			log.Println("using Rancher container IP " + service.IP);
+			log.Println("using container IP " + service.IP + " from label '" +
+				b.config.UseIpFromLabel  + "'")
+		} else {
+			log.Println("Label '" + b.config.UseIpFromLabel +
+				"' not found in container configuration")
 		}
 	}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -262,8 +262,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 	service.Port = p
 
-	//TODO: Add config.UseRancherContainerIP to config.... somehow
-	//if b.config.UseRancherContainerIP == true {
+	if b.config.UseRancherContainerIP == true {
 		containerIp := container.Config.Labels["io.rancher.container.ip"]
 		if containerIp != "" {
 			slashIndex := strings.LastIndex(containerIp, "/")
@@ -272,10 +271,9 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 			} else {
 				service.IP = containerIp
 			}
-			//log.Println("b.config.UseRancherContainerIP=" + b.config.UseRancherContainerIP + ", using Rancher container IP " + service.IP)
 			log.Println("using Rancher container IP " + service.IP);
 		}
-	//}
+	}
 
 	if port.PortType == "udp" {
 		service.Tags = combineTags(

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -22,6 +22,7 @@ type RegistryAdapter interface {
 type Config struct {
 	HostIp          string
 	Internal        bool
+	UseRancherContainerIP bool
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -22,7 +22,7 @@ type RegistryAdapter interface {
 type Config struct {
 	HostIp          string
 	Internal        bool
-	UseRancherContainerIP bool
+	UseIpFromLabel  string
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -43,6 +43,7 @@ Option                           | Since | Description
 `-tags <tags>`                   | v5    | Force comma-separated tags on all registered services
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
+`-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.
@@ -60,8 +61,8 @@ If you want unlimited retry-attempts use `-retry-attempts -1`.
 The `-resync` options controls how often Registrator will query Docker for all
 containers and reregister all services.  This allows Registrator and the service
 registry to get back in sync if they fall out of sync. Use this option with caution
-as it will notify all the watches you may have registered on your services, and 
-may rapidly flood your system (e.g. consul-template makes extensive use of watches). 
+as it will notify all the watches you may have registered on your services, and
+may rapidly flood your system (e.g. consul-template makes extensive use of watches).
 
 ## Consul ACL token
 

--- a/registrator.go
+++ b/registrator.go
@@ -20,7 +20,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
-var useRancherContainerIP = flag.Bool("useRancherContainerIP", false, "Use container IP assigned from the Rancher cluster (from container label 'io.rancher.container.ip') for registration")
+var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -99,7 +99,7 @@ func main() {
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
-		UseRancherContainerIP: *useRancherContainerIP,
+		UseIpFromLabel:  *useIpFromLabel,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,

--- a/registrator.go
+++ b/registrator.go
@@ -20,6 +20,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
+var useRancherContainerIP = flag.Bool("useRancherContainerIP", false, "Use container IP assigned from the Rancher cluster (from container label 'io.rancher.container.ip') for registration")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -98,6 +99,7 @@ func main() {
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
+		UseRancherContainerIP: *useRancherContainerIP,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,


### PR DESCRIPTION
These changes introduce the ability to use an IP address for registration of a container in Consul (or any other supported backend), which is stored in a label assigned to a Docker container.

This is especially useful when orchestrating containers in a cluster environment with different private network ranges, like e.g. [Rancher](http://rancher.com/).

See also the discussion at #454 for details.