### PR TITLE
Ability to use REGISTRATOR_BIND_ADDRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Added
+- Ability to use `REGISTRATOR_BIND_INTERFACE` env variable
 
 ### Removed
 
 ### Changed
+- Updated the alpine linux verion to `3.4`
 
 ## [v7] - 2016-03-05
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine:3.4
 
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk-install -t build-deps build-base go git mercurial \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM gliderlabs/alpine:3.3
-ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk-install -t build-deps build-base go git mercurial \
@@ -9,3 +8,8 @@ RUN apk-install -t build-deps build-base go git mercurial \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \
 	&& apk del --purge build-deps
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD "/bin/registrator"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+REGISTRATOR_BIND=
+if [ -n "$REGISTRATOR_BIND_INTERFACE" ]; then
+  REGISTRATOR_BIND_ADDRESS=$(ip -o -4 addr list $REGISTRATOR_BIND_INTERFACE | head -n1 | awk '{print $4}' | cut -d/ -f1)
+  if [ -z "$REGISTRATOR_BIND_ADDRESS" ]; then
+    echo "Could not find IP for interface '$REGISTRATOR_BIND_INTERFACE', exiting"
+    exit 1
+  fi
+
+  REGISTRATOR_BIND="-ip $REGISTRATOR_BIND_ADDRESS"
+  echo "==> Found address '$REGISTRATOR_BIND_ADDRESS' for interface '$REGISTRATOR_BIND_INTERFACE', setting bind option..."
+fi
+
+set -- registrator \
+    $REGISTRATOR_BIND \
+    "$@"
+
+exec "$@"


### PR DESCRIPTION
This commit adds small utility ENTRYPOINT to lookup the host ip address by interface name. To use this, set the `REGISTRATOR_BIND_INTERFACE ` environment variables to the name of the interface you'd like Registrator to use and a `-ip=<interface ip>argument will be computed and passed to Registrator at startup.
