### PR TITLE
Added support for DeregisterCriticalServiceAfter

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -122,6 +122,9 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 			check.Interval = DefaultInterval
 		}
 	}
+	if deregister_after := service.Attrs["check_deregister_after"]; deregister_after != "" {
+		check.DeregisterCriticalServiceAfter = deregister_after
+	}
 	return check
 }
 


### PR DESCRIPTION
This code allows to specify DeregisterCriticalServiceAfter interval for consul 0.7.0+ via environment variable SERVICE_*_CHECK_DEREGISTER_AFTER
