### PR TITLE
Adding log level

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,3 @@
+slackStatus "gici-automation", {
+  dockerBasic("devops/registrator")
+}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -16,6 +16,7 @@ import (
 )
 
 var serviceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
+var LOGLEVEL  = os.Getenv("LOGLEVEL")
 
 type Bridge struct {
 	sync.Mutex
@@ -82,7 +83,9 @@ func (b *Bridge) Refresh() {
 				log.Println("refresh failed:", service.ID, err)
 				continue
 			}
-			log.Println("refreshed:", containerId[:12], service.ID)
+			if LOGLEVEL == "1" {
+				log.Println("refreshed:", containerId[:12], service.ID)
+			}
 		}
 	}
 }
@@ -98,8 +101,9 @@ func (b *Bridge) Sync(quiet bool) {
 	} else if err != nil && !quiet {
 		log.Fatal(err)
 	}
-
-	log.Printf("Syncing services on %d containers", len(containers))
+	if LOGLEVEL == "1" {
+		log.Printf("Syncing services on %d containers", len(containers))
+	}
 
 	// NOTE: This assumes reregistering will do the right thing, i.e. nothing..
 	for _, listing := range containers {

--- a/registrator.go
+++ b/registrator.go
@@ -88,6 +88,10 @@ func main() {
 		os.Setenv("DOCKER_HOST", "unix:///tmp/docker.sock")
 	}
 
+	LOGLEVEL := os.Getenv("LOGLEVEL")
+	if LOGLEVEL == "" {
+		os.Setenv("LOGLEVEL", "0")
+	}
 	docker, err := dockerapi.NewClientFromEnv()
 	assert(err)
 


### PR DESCRIPTION
Level 1 - enable refresh log example:
2016/10/19 09:08:02 Syncing services on 6 containers
2016/10/19 09:08:12 refreshed: cae425da31a6 node-1:es-master-0:9300
2016/10/19 09:08:32 refreshed: cae425da31a6 node-1:es-master-0:9300
Level 0 - Disable this kind of logs in order to reduce registrator logs.

the param is set as env settings LOGLEVEL
