### PR TITLE
Tag templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 release
 build
+registrator

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -2,7 +2,6 @@ package bridge
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"log"
 	"net"

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -254,16 +254,22 @@ func mapTags(metadata map[string]string, container *dockerapi.Container) []strin
 	var tags []string
 	var tag bytes.Buffer
 	var metadata_tags = metadata["tags"]
-	tagTemplate := template.Must(template.New("tags").Parse(metadata_tags))
+	if len(metadata_tags) == 0 {
+		return tags
+	}
+	tagTemplate, errParse := template.New("tags").Parse(metadata_tags)
+	if errParse != nil {
+		log.Println("executing template:", errParse)
+		tags = strings.Split(metadata_tags, ",")
+		return tags
+	}
 	err := tagTemplate.Execute(&tag, container)
 	if err != nil {
 		log.Println("executing template:", err)
-		if len(metadata_tags) != 0 {
-			tags = strings.Split(metadata_tags, ",")
-		}
-	} else {
-		tags = strings.Split(tag.String(), ",")
+		tags = strings.Split(metadata_tags, ",")
+		return tags
 	}
+	tags = strings.Split(tag.String(), ",")
 	return tags
 }
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -258,8 +258,12 @@ func mapTags(metadata map[string]string, container *dockerapi.Container) []strin
 	err := tagTemplate.Execute(&tag, container)
 	if err != nil {
 		log.Println("executing template:", err)
+		if len(metadata_tags) != 0 {
+			tags = strings.Split(metadata_tags, ",")
+		}
+	} else {
+		tags = strings.Split(tag.String(), ",")
 	}
-	tags = strings.Split(tag.String(), ",")
 	return tags
 }
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -358,6 +358,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	delete(metadata, "name")
 	service.Attrs = metadata
 	service.TTL = b.config.RefreshTtl
+	service.Tags = mappedTags
 
 	return service
 }

--- a/compose_examples/README.md
+++ b/compose_examples/README.md
@@ -1,0 +1,9 @@
+Example of registrator use using docker-compose.
+To run an exemple, just pick a file say ``` <example_name> ```
+And run it using
+```
+docker-compose -f <example_name> up
+```
+
+In case docker-compose is not installed, use the installation
+helper [here](https://docs.docker.com/compose/install)

--- a/compose_examples/invalid-template-example.compose.yml
+++ b/compose_examples/invalid-template-example.compose.yml
@@ -21,7 +21,7 @@ services:
         labels:
             com.delairtech.test.registrator: test_local
         environment:
-            SERVICE_80_TAGS: 'test_label=test_value'
+            SERVICE_80_TAGS: 'com.delairtech.test.registrator={{index .Config.Labels "com.delairtech.test.registrator",{{.ID}}'
         ports:
             - "80:80"
         command:

--- a/compose_examples/no-tags-example.compose.yml
+++ b/compose_examples/no-tags-example.compose.yml
@@ -20,8 +20,6 @@ services:
         image: ubuntu:latest
         labels:
             com.delairtech.test.registrator: test_local
-        environment:
-            SERVICE_80_TAGS: 'test_label=test_value'
         ports:
             - "80:80"
         command:

--- a/compose_examples/tags-example.compose.yml
+++ b/compose_examples/tags-example.compose.yml
@@ -21,7 +21,7 @@ services:
         labels:
             com.delairtech.test.registrator: test_local
         environment:
-            SERVICE_80_TAGS: "com.delairtech.test.resgistrator={{Config.Labels.com.delairtech.test.registrator}},{{Id}}"
+            SERVICE_80_TAGS: 'com.delairtech.test.registrator={{index .Config.Labels "com.delairtech.test.registrator"}},{{.ID}}'
         ports:
             - "80:80"
         command:

--- a/compose_examples/tags-example.compose.yml
+++ b/compose_examples/tags-example.compose.yml
@@ -1,0 +1,46 @@
+version: "2.0"
+
+services:
+
+    consul:
+        image: consul:latest
+        environment:
+            CONSUL_LOCAL_CONFIG: '{"leave_on_terminate": true}'
+        network_mode: "host"
+        command:
+            - consul
+            - agent
+            - -server
+            - -ui
+            - -dev
+            - -bind
+            - 127.0.0.1
+
+    ubuntutest:
+        image: ubuntu:latest
+        labels:
+            com.delairtech.test.registrator: test_local
+        environment:
+            SERVICE_80_TAGS: "com.delairtech.test.resgistrator={{Config.Labels.com.delairtech.test.registrator}},{{Id}}"
+        ports:
+            - "80:80"
+        command:
+            - sleep
+            - "27400"
+
+    registrator:
+        image: golang
+        network_mode: "host"
+        volumes:
+            - "$GOPATH:/go"
+            - "/var/run/docker.sock:/tmp/docker.sock"
+        environment:
+            - "GOPATH=/go"
+        command:
+            - /go/src/github.com/gliderlabs/registrator/registrator
+            - -retry-attempts=5
+            - -retry-interval=5000
+            - consul://127.0.0.1:8500
+        depends_on:
+            - consul
+            - ubuntutest

--- a/compose_examples/tags-template-example.compose.yml
+++ b/compose_examples/tags-template-example.compose.yml
@@ -21,7 +21,7 @@ services:
         labels:
             com.delairtech.test.registrator: test_local
         environment:
-            SERVICE_80_TAGS: 'test_label=test_value'
+            SERVICE_80_TAGS: 'com.delairtech.test.registrator={{index .Config.Labels "com.delairtech.test.registrator"}},{{.ID}}'
         ports:
             - "80:80"
         command:


### PR DESCRIPTION
This PR enables you to use container related value inside registrator tags. When you use a {{ <path> }} string inside a container tag, the string is replaced by the value of the <path> key inside docker inspect.

An example is available in compose_examples directory