### PR TITLE
Build possible IP:Port list from inspect, and filter which IP:Port should be reported by daemon option and container labels

### DIFF
--- a/bridge/filter.go
+++ b/bridge/filter.go
@@ -1,0 +1,201 @@
+package bridge
+
+import (
+	"errors"
+	"math"
+	"net"
+	"strconv"
+	"strings"
+)
+
+type Filter struct {
+	hostIP      bool        // if true, host ip is accepted (external)
+	containerIP bool        // if true, container ip is accepted (internal)
+	ip          net.IP      // ip address
+	ipnet       *net.IPNet  // ip range
+	portLess    bool        // if true, ip only (no port)
+	portMin     uint16      // port range min
+	portMax     uint16      // port range max
+	proto       string      // protocol (tcp/udp)
+
+}
+type Filters struct {
+	list []*Filter
+}
+
+// clear the filter lists
+func (f *Filters) Clear() {
+	f.list = []*Filter{}
+}
+
+// build a filter lists from input string
+// input string is comma separated filter-string lists
+// filter-string contains ip(or range):port(or range)/proto(tcp or udp) format
+func (f *Filters) Append(input string) error {
+	if len(input) == 0 {
+		return nil
+	}
+	entries := strings.Split(input, ",")
+	for _, entry := range entries {
+		if len(entry) == 0 {
+			return errors.New("empty filter entry exist")
+		}
+		filter := new(Filter)
+		ipPort := strings.Split(entry, ":")
+		if err := parseIp(ipPort[0], filter); err != nil {
+			return err
+		}
+		if len(ipPort) > 1 {
+			if err := parsePort(ipPort[1], filter); err != nil {
+				return err
+			}
+		} else {
+			filter.portLess = true
+		}
+		f.list = append(f.list, filter)
+	}
+	return nil
+}
+
+// check ip:port is matched with one of filter in list
+// returned with matched filter for informations
+func (f *Filters) Match(ip string, port uint16, internal bool) (bool, *Filter, error) {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return false, nil, errors.New("parse ip address error : " + ip)
+	}
+	for _, filter := range f.list {
+		matched, _, err := matchIPPort(parsedIP, port, internal, filter)
+		if err != nil {
+			return false, nil, err
+		}
+		if matched {
+			return true, filter, nil
+		}
+	}
+	return false, nil, nil
+}
+
+// parse input string and generate filter ip parts
+// input string must be ip (ex 192.168.1.1) or cidr (ex 192.168.0.0/16)
+func parseIp(input string, filter *Filter) error {
+	if strings.EqualFold(input, "host") {
+		filter.hostIP = true
+		return nil
+	}
+	if strings.EqualFold(input, "container") {
+		filter.containerIP = true
+		return nil
+	}
+	if strings.EqualFold(input, "0.0.0.0") {
+		_, filter.ipnet, _ = net.ParseCIDR("0.0.0.0/0")
+		return nil
+	}
+	if strings.Contains(input, "/") {
+		_, ipnet, err := net.ParseCIDR(input)
+		if err != nil {
+			return err
+		}
+		filter.ipnet = ipnet
+		return nil
+	}
+	ip := net.ParseIP(input)
+	if ip == nil {
+		return errors.New("parse ip address error : " + input)
+	}
+	filter.ip = ip
+	return nil
+}
+
+// parse input string and generate filter port/port-range and protocol parts
+// input string must be port (ex 80) or port range (ex 80-8080)
+// and "/" separated protocol string can be appended (ex /udp)
+func parsePort(input string, filter *Filter) error {
+	portProto := strings.Split(input, "/")
+	if len(portProto) >= 2 {
+		if err := parseProto(portProto[1], filter); err != nil {
+			return err
+		}
+	} else {
+		filter.proto = "tcp"
+	}
+	// "*" means any port so min value is 0 and max value is uint16 max
+	if strings.EqualFold(portProto[0], "*") {
+		filter.portMin = 0
+		filter.portMax = math.MaxUint16
+		return nil
+	}
+	// if port string is separated with "-", it should be range of port
+	// if port string isn't separated with "-", it should be a port
+	ports := strings.Split(portProto[0], "-")
+	v1, err := strconv.ParseUint(ports[0], 10, 16)
+	if err != nil {
+		return errors.New("parse port error : " + portProto[0])
+	}
+	filter.portMin = uint16(v1)
+	if len(ports) >= 2 {
+		v2, err := strconv.ParseUint(ports[1], 10, 16)
+		if err != nil {
+			return errors.New("parse port range error : " + portProto[0])
+		}
+		filter.portMax = uint16(v2)
+	} else {
+		filter.portMax = uint16(v1)
+	}
+	return nil
+}
+
+// parse protocol name (tcp or udp)
+// if proto is not specified in input-string, doesn't call this function.
+// so empty or strange strings must be returned error
+func parseProto(input string, filter *Filter) error {
+	if strings.EqualFold(input, "tcp") {
+		filter.proto = "tcp"
+		return nil
+	}
+	if strings.EqualFold(input, "udp") {
+		filter.proto = "udp"
+		return nil
+	}
+	return errors.New("parse protocol error : " + input)
+}
+
+// match ip:port with a filter
+// at first check ip is matched with filter and if matched, check port is matched
+func matchIPPort(ip net.IP, port uint16, internal bool, filter *Filter) (bool, *Filter, error) {
+	// check ip
+	// if filter is accept any host ip
+	if filter.hostIP == true && internal == false {
+		return matchPort(port, filter)
+	}
+	// if filter is accept any container ip
+	if filter.containerIP == true && internal == true {
+		return matchPort(port, filter)
+	}
+	// if filter is accept ip
+	if filter.ip != nil {
+		if filter.ip.Equal(ip) {
+			return matchPort(port, filter)
+		}
+	}
+	// if filter is accept ip range
+	if filter.ipnet != nil {
+		if filter.ipnet.Contains(ip) {
+			return matchPort(port, filter)
+		}
+	}
+	// not matched with filter ip/port
+	return false, nil, nil
+}
+
+// match port with a filter
+// portless means report ip address only (without port) so if portless is true, always return true
+func matchPort(port uint16, filter *Filter) (bool, *Filter, error) {
+	if filter.portLess == true {
+		return true, filter, nil
+	}
+	if filter.portMin <= port && filter.portMax >= port {
+		return true, filter, nil
+	}
+	return false, nil, nil
+}

--- a/bridge/filter_test.go
+++ b/bridge/filter_test.go
@@ -1,0 +1,108 @@
+package bridge
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchPorts(t *testing.T) {
+	var filters Filters
+
+	filters.Clear()
+	if err := filters.Append("192.168.1.1:80"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ := filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result, "test single ip:port match")
+	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	assert.False(t, result, "test single ip:port notmatch")
+	result, _, _ = filters.Match("192.168.1.2", 80, false)
+	assert.False(t, result, "test single ip:port notmatch")
+
+	filters.Clear()
+	if err := filters.Append("192.168.1.1:*"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result, "test single ip with wildcard port")
+	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	assert.True(t, result, "test single ip with wildcard port")
+	result, _, _ = filters.Match("192.168.1.2", 80, false)
+	assert.False(t, result, "test single ip with wildcard port")
+
+	filters.Clear()
+	if err := filters.Append("192.168.1.0/24:*"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result, "test ip range with wildcard port")
+	result, _, _ = filters.Match("192.168.1.254", 81, false)
+	assert.True(t, result, "test ip range with wildcard port")
+
+	filters.Clear()
+	if err := filters.Append("0.0.0.0:*"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result, "test wildcard ip with wildcard port")
+	result, _, _ = filters.Match("192.168.1.2", 82, false)
+	assert.True(t, result, "test wildcard ip with wildcard port")
+
+	filters.Clear()
+	if err := filters.Append("0.0.0.0:8080"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.False(t, result, "test wildcard ip with port")
+	result, _, _ = filters.Match("192.168.1.2", 8080, false)
+	assert.True(t, result, "test wildcard ip with port")
+
+	filters.Clear()
+	if err := filters.Append("0.0.0.0:80-82"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result, "test wildcard ip with port range")
+	result, _, _ = filters.Match("192.168.1.2", 81, false)
+	assert.True(t, result, "test wildcard ip with port range")
+	result, _, _ = filters.Match("192.168.1.3", 82, false)
+	assert.True(t, result, "test wildcard ip with port range")
+	result, _, _ = filters.Match("192.168.1.1", 83, false)
+	assert.False(t, result, "test wildcard ip with port range")
+
+	// check host/container ip
+	filters.Clear()
+	if err := filters.Append("host:80-82"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	assert.True(t, result)
+	result, _, _ = filters.Match("192.168.1.1", 81, true)
+	assert.False(t, result)
+	filters.Clear()
+	if err := filters.Append("container:80-82"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 81, true)
+	assert.True(t, result)
+	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	assert.False(t, result)
+
+
+	// check with multi-value
+	filters.Clear()
+	if err := filters.Append("192.168.1.1:80,192.168.1.2:81,0.0.0.0:83-84"); err != nil {
+		t.Logf("error: %s\n", err.Error())
+	}
+	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	assert.True(t, result)
+	result, _, _ = filters.Match("192.168.1.2", 81, false)
+	assert.True(t, result)
+	result, _, _ = filters.Match("192.168.1.3", 83, false)
+	assert.True(t, result)
+	result, _, _ = filters.Match("10.0.0.1", 84, false)
+	assert.True(t, result)
+	result, _, _ = filters.Match("192.168.1.3", 81, false)
+	assert.False(t, result)
+
+}

--- a/bridge/filter_test.go
+++ b/bridge/filter_test.go
@@ -12,80 +12,80 @@ func TestMatchPorts(t *testing.T) {
 	if err := filters.Append("192.168.1.1:80"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ := filters.Match("192.168.1.1", 80, false)
+	result, _, _ := filters.Match("192.168.1.1", "80/tcp", false)
 	assert.True(t, result, "test single ip:port match")
-	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",false)
 	assert.False(t, result, "test single ip:port notmatch")
-	result, _, _ = filters.Match("192.168.1.2", 80, false)
+	result, _, _ = filters.Match("192.168.1.2", "80/tcp",false)
 	assert.False(t, result, "test single ip:port notmatch")
 
 	filters.Clear()
 	if err := filters.Append("192.168.1.1:*"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80/tcp",false)
 	assert.True(t, result, "test single ip with wildcard port")
-	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",false)
 	assert.True(t, result, "test single ip with wildcard port")
-	result, _, _ = filters.Match("192.168.1.2", 80, false)
+	result, _, _ = filters.Match("192.168.1.2", "80",false)
 	assert.False(t, result, "test single ip with wildcard port")
 
 	filters.Clear()
 	if err := filters.Append("192.168.1.0/24:*"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80",false)
 	assert.True(t, result, "test ip range with wildcard port")
-	result, _, _ = filters.Match("192.168.1.254", 81, false)
+	result, _, _ = filters.Match("192.168.1.254", "81/tcp",false)
 	assert.True(t, result, "test ip range with wildcard port")
 
 	filters.Clear()
 	if err := filters.Append("0.0.0.0:*"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80",false)
 	assert.True(t, result, "test wildcard ip with wildcard port")
-	result, _, _ = filters.Match("192.168.1.2", 82, false)
+	result, _, _ = filters.Match("192.168.1.2", "82/tcp",false)
 	assert.True(t, result, "test wildcard ip with wildcard port")
 
 	filters.Clear()
 	if err := filters.Append("0.0.0.0:8080"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80/tcp",false)
 	assert.False(t, result, "test wildcard ip with port")
-	result, _, _ = filters.Match("192.168.1.2", 8080, false)
+	result, _, _ = filters.Match("192.168.1.2", "8080/tcp",false)
 	assert.True(t, result, "test wildcard ip with port")
 
 	filters.Clear()
 	if err := filters.Append("0.0.0.0:80-82"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80/tcp",false)
 	assert.True(t, result, "test wildcard ip with port range")
-	result, _, _ = filters.Match("192.168.1.2", 81, false)
+	result, _, _ = filters.Match("192.168.1.2", "81/tcp",false)
 	assert.True(t, result, "test wildcard ip with port range")
-	result, _, _ = filters.Match("192.168.1.3", 82, false)
+	result, _, _ = filters.Match("192.168.1.3", "82/tcp",false)
 	assert.True(t, result, "test wildcard ip with port range")
-	result, _, _ = filters.Match("192.168.1.1", 83, false)
+	result, _, _ = filters.Match("192.168.1.1", "83/tcp",false)
 	assert.False(t, result, "test wildcard ip with port range")
 
 	// check host/container ip
 	filters.Clear()
-	if err := filters.Append("host:80-82"); err != nil {
+	if err := filters.Append("external:80-82"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",false)
 	assert.True(t, result)
-	result, _, _ = filters.Match("192.168.1.1", 81, true)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",true)
 	assert.False(t, result)
 	filters.Clear()
-	if err := filters.Append("container:80-82"); err != nil {
+	if err := filters.Append("internal:80-82"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 81, true)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",true)
 	assert.True(t, result)
-	result, _, _ = filters.Match("192.168.1.1", 81, false)
+	result, _, _ = filters.Match("192.168.1.1", "81/tcp",false)
 	assert.False(t, result)
 
 
@@ -94,15 +94,15 @@ func TestMatchPorts(t *testing.T) {
 	if err := filters.Append("192.168.1.1:80,192.168.1.2:81,0.0.0.0:83-84"); err != nil {
 		t.Logf("error: %s\n", err.Error())
 	}
-	result, _, _ = filters.Match("192.168.1.1", 80, false)
+	result, _, _ = filters.Match("192.168.1.1", "80/tcp",false)
 	assert.True(t, result)
-	result, _, _ = filters.Match("192.168.1.2", 81, false)
+	result, _, _ = filters.Match("192.168.1.2", "81/tcp",false)
 	assert.True(t, result)
-	result, _, _ = filters.Match("192.168.1.3", 83, false)
+	result, _, _ = filters.Match("192.168.1.3", "83/tcp",false)
 	assert.True(t, result)
-	result, _, _ = filters.Match("10.0.0.1", 84, false)
+	result, _, _ = filters.Match("10.0.0.1", "84/tcp",false)
 	assert.True(t, result)
-	result, _, _ = filters.Match("192.168.1.3", 81, false)
+	result, _, _ = filters.Match("192.168.1.3", "81/tcp",false)
 	assert.False(t, result)
 
 }

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -20,15 +20,13 @@ type RegistryAdapter interface {
 }
 
 type Config struct {
-	HostIp          string
-	Internal        bool
-	UseIpFromLabel  string
+	Filter          string
+	Intf     	string
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
-	Filter          string
 }
 
 type Service struct {
@@ -45,7 +43,7 @@ type Service struct {
 
 type DeadContainer struct {
 	TTL      int
-	Services []*Service
+	Services map[string]*Service
 }
 
 type ServicePort struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -28,6 +28,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+	Filter          string
 }
 
 type Service struct {

--- a/registrator.go
+++ b/registrator.go
@@ -29,6 +29,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var filter = flag.String("filter", "", "Filter for IP:Port pair")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -105,6 +106,7 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
+		Filter:          *filter,
 	})
 
 	assert(err)

--- a/registrator.go
+++ b/registrator.go
@@ -21,7 +21,6 @@ var versionChecker = usage.NewChecker("registrator", Version)
 var filter = flag.String("filter", "external:*", "Comma separated filter for \"IP\":\"Port\" pairs.\n" +
 	"        \"IP\" can be a single ip address or CIDR (ex. 192.168.1.1 192.168.1.0/24)\n" +
 	"        \"Port\" can be a single number or \"-\" separated range of ports\n" +
-	"          0       : Only IP address is registered\n" +
 	"          *       : Any ports\n" +
 	"          80-8080 : Ports range from 80 to 8080\n" +
 	"        Protocol can be appended ends of ports with \"/\" separated. (ex. 80/tcp 53/udp)\n" +

--- a/registrator.go
+++ b/registrator.go
@@ -29,7 +29,14 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
-var filter = flag.String("filter", "", "Filter for IP:Port pair")
+var filter = flag.String("filter", "", "Comma separated filter for \"IP\":\"Port\" pairs.\n" +
+	"        \"IP\" can be a single ip address or CIDR (ex. 192.168.1.1 192.168.1.0/24)\n" +
+	"        \"Port\" can be a single number or \"-\" separated range of ports\n" +
+	"          0       : Only IP address is registered\n" +
+	"          *       : Any ports\n" +
+	"          80-8080 : Ports range from 80 to 8080\n" +
+	"        Protocol can be appended ends of ports with \"/\" separated. (ex. 80/tcp 53/udp)\n" +
+	"        If container label \"REGISTRATOR_FILTER\" is defined, use it instead of this option")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {


### PR DESCRIPTION
#### About this PR
I have proposed an idea with Issue #508, but no one has commented yet.
My idea is that the registrator will create all IP:Port list, and specify the filter to which IP:Port should be registered with the daemon option or container label.
However, in actual implementation, my idea seems to be unacceptable because there is a lot of conflict with existing implementation.
I'm sending a PR to show you what the idea was about the proposed issue ( #508 ) , but I do not think this PR will be accepted.
I just want you to understand that I made such an effort to make a better world. :)
 
#### Ideas implemented in PR

- Possible IP:Port List
  - Get a list of ports in Container Inspect
    - Port opened by container and Port exposed by host
  - Retrieve all Network lists from Container Inspect
    - It is divided into host, internal (ex. bridge, overlay) and external (ex. macvlan, ipvlan) depending on the driver type of the network.
  - Obtain an IP:Port list that can be used by combining the IP and Port list generated by the above operation.

- IP: Port filter
  - Set IP or IP range to register and port or port range to register (ex. 192.168.0.0/16:80-82/tcp)
  - Check if IP:Port list matches this filter condition