### PR TITLE
Add SERVICE_{}_CHECK_PORT option.

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"strings"
 	"os"
+	"strings"
+
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-cleanhttp"
@@ -33,16 +34,16 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	if uri.Scheme == "consul-unix" {
 		config.Address = strings.TrimPrefix(uri.String(), "consul-")
 	} else if uri.Scheme == "consul-tls" {
-	        tlsConfigDesc := &consulapi.TLSConfig {
-			  Address: uri.Host,
-			  CAFile: os.Getenv("CONSUL_CACERT"),
-  			  CertFile: os.Getenv("CONSUL_TLSCERT"),
-  			  KeyFile: os.Getenv("CONSUL_TLSKEY"),
-			  InsecureSkipVerify: false,
+		tlsConfigDesc := &consulapi.TLSConfig{
+			Address:            uri.Host,
+			CAFile:             os.Getenv("CONSUL_CACERT"),
+			CertFile:           os.Getenv("CONSUL_TLSCERT"),
+			KeyFile:            os.Getenv("CONSUL_TLSKEY"),
+			InsecureSkipVerify: false,
 		}
 		tlsConfig, err := consulapi.SetupTLSConfig(tlsConfigDesc)
 		if err != nil {
-		   log.Fatal("Cannot set up Consul TLSConfig", err)
+			log.Fatal("Cannot set up Consul TLSConfig", err)
 		}
 		config.Scheme = "https"
 		transport := cleanhttp.DefaultPooledTransport()
@@ -91,13 +92,17 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	if status := service.Attrs["check_initial_status"]; status != "" {
 		check.Status = status
 	}
+	checkPort := fmt.Sprintf("%d", service.Port)
+	if port := service.Attrs["check_port"]; port != "" {
+		checkPort = service.Attrs["check_port"]
+	}
 	if path := service.Attrs["check_http"]; path != "" {
-		check.HTTP = fmt.Sprintf("http://%s:%d%s", service.IP, service.Port, path)
+		check.HTTP = fmt.Sprintf("http://%s:%s%s", service.IP, checkPort, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}
 	} else if path := service.Attrs["check_https"]; path != "" {
-		check.HTTP = fmt.Sprintf("https://%s:%d%s", service.IP, service.Port, path)
+		check.HTTP = fmt.Sprintf("https://%s:%s%s", service.IP, checkPort, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}
@@ -108,7 +113,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
-		check.TCP = fmt.Sprintf("%s:%d", service.IP, service.Port)
+		check.TCP = fmt.Sprintf("%s:%s", service.IP, checkPort)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -34,6 +34,7 @@ register an HTTP health check with the service.
 SERVICE_80_CHECK_HTTP=/health/endpoint/path
 SERVICE_80_CHECK_INTERVAL=15s
 SERVICE_80_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
+SERVICE_80_CHECK_PORT=81		# optional, if you want to do a check on different port than service one.
 ```
 
 It works for services on any port, not just 80. If its the only service,
@@ -49,6 +50,7 @@ register an HTTPS health check with the service.
 SERVICE_443_CHECK_HTTPS=/health/endpoint/path
 SERVICE_443_CHECK_INTERVAL=15s
 SERVICE_443_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
+SERVICE_443_CHECK_PORT=444		# optional, if you want to do a check on different port than service one.
 ```
 
 ### Consul TCP Check
@@ -58,9 +60,10 @@ specifying these extra metadata in labels or environment will be used to
 register an TCP health check with the service.
 
 ```bash
-SERVICE_443_CHECK_TCP=true
-SERVICE_443_CHECK_INTERVAL=15s
-SERVICE_443_CHECK_TIMEOUT=3s		# optional, Consul default used otherwise
+SERVICE_1234_CHECK_TCP=true
+SERVICE_1234_CHECK_INTERVAL=15s
+SERVICE_1234_CHECK_TIMEOUT=3s		# optional, Consul default used otherwise
+SERVICE_1234_CHECK_PORT=1235		# optional, if you want to do a check on different port than service one.
 ```
 
 ### Consul Script Check


### PR DESCRIPTION
Allow specifying a health check port to be different than a service one.

Use case.
We have a container listening on two ports: 111, 222. We want to ignore service on port 111 from being registered on Consul via `SERVICE_111_IGNORE=1` and register service on port 222 with a health check targeting the other port, i.e. `http://SERVICE_IP:222/healthcheck`