### PR TITLE
Implement consul service attribute storage in KV

### DIFF
--- a/bridge/types.go
+++ b/bridge/types.go
@@ -17,6 +17,8 @@ type RegistryAdapter interface {
 	Deregister(service *Service) error
 	Refresh(service *Service) error
 	Services() ([]*Service, error)
+	RemoveAttributes(service *Service) error
+	PostAttributes(service *Service) error
 }
 
 type Config struct {

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -65,6 +65,16 @@ func (r *ConsulKVAdapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *ConsulKVAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *ConsulKVAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *ConsulKVAdapter) Deregister(service *bridge.Service) error {
 	path := r.path[1:] + "/" + service.Name + "/" + service.ID
 	_, err := r.client.KV().Delete(path, nil)

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -102,6 +102,16 @@ func (r *EtcdAdapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *EtcdAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *EtcdAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *EtcdAdapter) Deregister(service *bridge.Service) error {
 	r.syncEtcdCluster()
 

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -53,6 +53,16 @@ func (r *Skydns2Adapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *Skydns2Adapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *Skydns2Adapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *Skydns2Adapter) Deregister(service *bridge.Service) error {
 	_, err := r.client.Delete(r.servicePath(service), false)
 	if err != nil {

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -89,6 +89,16 @@ func (r *ZkAdapter) Ping() error {
 	return nil
 }
 
+func (r *ZkAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *ZkAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *ZkAdapter) Deregister(service *bridge.Service) error {
 	basePath := r.path + "/" + service.Name
 	if (r.path == "/") {


### PR DESCRIPTION
I changed the implementation so that the KV pair which defines the attributes for a service is only removed when the last instance of the service is removed.