### PR TITLE
Feature/save attrs in kv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.5
-ENTRYPOINT ["/bin/registrator"]
+#ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk --no-cache add -t build-deps build-base go git \
@@ -8,6 +8,6 @@ RUN apk --no-cache add -t build-deps build-base go git \
 	&& export GOPATH=/go \
   && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
-	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
-	&& rm -rf /go \
-	&& apk del --purge build-deps
+	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator # \
+#	&& rm -rf /go \
+#	&& apk del --purge build-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.5
-#ENTRYPOINT ["/bin/registrator"]
+ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk --no-cache add -t build-deps build-base go git \
@@ -8,6 +8,6 @@ RUN apk --no-cache add -t build-deps build-base go git \
 	&& export GOPATH=/go \
   && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
-	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator # \
-#	&& rm -rf /go \
-#	&& apk del --purge build-deps
+	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator  \
+	&& rm -rf /go \
+	&& apk del --purge build-deps

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -347,6 +347,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	return service
 }
 
+
 func (b *Bridge) remove(containerId string, deregister bool) {
 	b.Lock()
 	defer b.Unlock()
@@ -362,6 +363,7 @@ func (b *Bridge) remove(containerId string, deregister bool) {
 			}
 		}
 		cleanUpAttrs := func(services []*Service) {
+		    b.registry.AcquireDistributedLock()
             distServices, err := b.registry.DistributedServices()
             if err != nil {
                 log.Println("Failed to list distributed services: ", err)
@@ -374,6 +376,7 @@ func (b *Bridge) remove(containerId string, deregister bool) {
                     log.Println("Service was not found elsewhere... Attrs will be removed:", service.Name)
                 }
 			}
+			b.registry.ReleaseDistributedLock()
 		}
 		deregisterAll(b.services[containerId])
 		cleanUpAttrs(b.services[containerId])

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -19,6 +19,7 @@ type RegistryAdapter interface {
 	Services() ([]*Service, error)
 	RemoveAttributes(service *Service) error
 	PostAttributes(service *Service) error
+	DistributedServices() (map[string][]string, error)
 }
 
 type Config struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -17,6 +17,8 @@ type RegistryAdapter interface {
 	Deregister(service *Service) error
 	Refresh(service *Service) error
 	Services() ([]*Service, error)
+	RemoveAttributes(service *Service) error
+	PostAttributes(service *Service) error
 }
 
 type Config struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -20,6 +20,8 @@ type RegistryAdapter interface {
 	RemoveAttributes(service *Service) error
 	PostAttributes(service *Service) error
 	DistributedServices() (map[string][]string, error)
+	AcquireDistributedLock() error
+	ReleaseDistributedLock() error
 }
 
 type Config struct {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -83,6 +83,7 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 	registration.Tags = service.Tags
 	registration.Address = service.IP
 	registration.Check = r.buildCheck(service)
+	r.PostAttributes(service)
 	return r.client.Agent().ServiceRegister(registration)
 }
 
@@ -123,6 +124,35 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		}
 	}
 	return check
+}
+
+func (r *ConsulAdapter) PostAttributes(service *bridge.Service) error {
+	for k, v := range service.Attrs {
+		data := new(consulapi.KVPair)
+		data.Key = buildServiceKey(service, k)
+		data.Value = []byte(v)
+		log.Println("Updating Consul KV: ", data.Key, v)
+		_, err := r.client.KV().Put(data, nil)
+		if err != nil {
+			log.Println("Error Updating Attribute: ", err)
+		}
+	}
+	return nil
+}
+
+func buildServiceKey(service *bridge.Service, key string) string {
+	return fmt.Sprintf(
+		"service/%s/meta/%s",
+		service.Name,
+		key,
+	)
+}
+
+func (r *ConsulAdapter) RemoveAttributes(service *bridge.Service) error {
+	for k, _ := range service.Attrs {
+		r.client.KV().Delete(buildServiceKey(service, k), nil)
+	}
+	return nil
 }
 
 func (r *ConsulAdapter) Deregister(service *bridge.Service) error {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -183,3 +183,21 @@ func (r *ConsulAdapter) Services() ([]*bridge.Service, error) {
 	}
 	return out, nil
 }
+
+//This method queries for all distributed services, not just those managed locally
+func (r *ConsulAdapter) GetDistributedLockHandler() (map[string][]string, error) {
+	services, _, err := r.client.Catalog().Services(&consulapi.QueryOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return services, nil
+}
+
+//This method queries for all distributed services, not just those managed locally
+func (r *ConsulAdapter) DistributedServices() (map[string][]string, error) {
+	services, _, err := r.client.Catalog().Services(&consulapi.QueryOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return services, nil
+}

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -56,11 +56,16 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	if err != nil {
 		log.Fatal("consul: ", uri.Scheme)
 	}
-	return &ConsulAdapter{client: client}
+    lock, err := client.LockKey("lock/adapter/distributedservices")
+    if err != nil {
+		log.Fatal("Failed to create LockKey: ", uri.Scheme)
+	}
+	return &ConsulAdapter{client: client, distributedlock: lock}
 }
 
 type ConsulAdapter struct {
 	client *consulapi.Client
+	distributedlock *consulapi.Lock
 }
 
 // Ping will try to connect to consul by attempting to retrieve the current leader.
@@ -184,13 +189,20 @@ func (r *ConsulAdapter) Services() ([]*bridge.Service, error) {
 	return out, nil
 }
 
-//This method queries for all distributed services, not just those managed locally
-func (r *ConsulAdapter) GetDistributedLockHandler() (map[string][]string, error) {
-	services, _, err := r.client.Catalog().Services(&consulapi.QueryOptions{})
-	if err != nil {
-		return nil, err
+func (r *ConsulAdapter) AcquireDistributedLock() error {
+    _, err := r.distributedlock.Lock(nil)
+    if err != nil {
+		return err
 	}
-	return services, nil
+    return nil
+}
+
+func (r *ConsulAdapter) ReleaseDistributedLock() error {
+    err := r.distributedlock.Unlock()
+    if err != nil {
+		return err
+	}
+    return nil
 }
 
 //This method queries for all distributed services, not just those managed locally

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -65,6 +65,16 @@ func (r *ConsulKVAdapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *ConsulKVAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *ConsulKVAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *ConsulKVAdapter) Deregister(service *bridge.Service) error {
 	path := r.path[1:] + "/" + service.Name + "/" + service.ID
 	_, err := r.client.KV().Delete(path, nil)

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -92,6 +92,16 @@ func (r *ConsulKVAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
 
+func (r *ConsulKVAdapter) AcquireDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
+func (r *ConsulKVAdapter) ReleaseDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
 //This method queries for all distributed services, not just those managed locally
 func (r *ConsulKVAdapter) DistributedServices() (map[string][]string, error) {
     // PLACEHOLDER: This method is yet to be implemented

--- a/consulkv/consulkv.go
+++ b/consulkv/consulkv.go
@@ -91,3 +91,9 @@ func (r *ConsulKVAdapter) Refresh(service *bridge.Service) error {
 func (r *ConsulKVAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
+
+//This method queries for all distributed services, not just those managed locally
+func (r *ConsulKVAdapter) DistributedServices() (map[string][]string, error) {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil, nil
+}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -137,3 +137,9 @@ func (r *EtcdAdapter) Refresh(service *bridge.Service) error {
 func (r *EtcdAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
+
+//This method queries for all distributed services, not just those managed locally
+func (r *EtcdAdapter) DistributedServices() (map[string][]string, error) {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil, nil
+}

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -138,6 +138,16 @@ func (r *EtcdAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
 
+func (r *EtcdAdapter) AcquireDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
+func (r *EtcdAdapter) ReleaseDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
 //This method queries for all distributed services, not just those managed locally
 func (r *EtcdAdapter) DistributedServices() (map[string][]string, error) {
     // PLACEHOLDER: This method is yet to be implemented

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -102,6 +102,16 @@ func (r *EtcdAdapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *EtcdAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *EtcdAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *EtcdAdapter) Deregister(service *bridge.Service) error {
 	r.syncEtcdCluster()
 

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -79,6 +79,12 @@ func (r *Skydns2Adapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
 
+//This method queries for all distributed services, not just those managed locally
+func (r *Skydns2Adapter) DistributedServices() (map[string][]string, error) {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil, nil
+}
+
 func (r *Skydns2Adapter) servicePath(service *bridge.Service) string {
 	return r.path + "/" + service.Name + "/" + service.ID
 }
@@ -90,3 +96,4 @@ func domainPath(domain string) string {
 	}
 	return "/skydns/" + strings.Join(components, "/")
 }
+

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -79,6 +79,16 @@ func (r *Skydns2Adapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
 
+func (r *Skydns2Adapter) AcquireDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
+func (r *Skydns2Adapter) ReleaseDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
 //This method queries for all distributed services, not just those managed locally
 func (r *Skydns2Adapter) DistributedServices() (map[string][]string, error) {
     // PLACEHOLDER: This method is yet to be implemented

--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -53,6 +53,16 @@ func (r *Skydns2Adapter) Register(service *bridge.Service) error {
 	return err
 }
 
+func (r *Skydns2Adapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *Skydns2Adapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *Skydns2Adapter) Deregister(service *bridge.Service) error {
 	_, err := r.client.Delete(r.servicePath(service), false)
 	if err != nil {

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -130,3 +130,10 @@ func (r *ZkAdapter) Refresh(service *bridge.Service) error {
 func (r *ZkAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
+
+//This method queries for all distributed services, not just those managed locally
+func (r *ZkAdapter) DistributedServices() (map[string][]string, error) {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil, nil
+}
+

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -131,6 +131,16 @@ func (r *ZkAdapter) Services() ([]*bridge.Service, error) {
 	return []*bridge.Service{}, nil
 }
 
+func (r *ZkAdapter) AcquireDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
+func (r *ZkAdapter) ReleaseDistributedLock() error {
+    // PLACEHOLDER: This method is yet to be implemented
+    return nil
+}
+
 //This method queries for all distributed services, not just those managed locally
 func (r *ZkAdapter) DistributedServices() (map[string][]string, error) {
     // PLACEHOLDER: This method is yet to be implemented

--- a/zookeeper/zookeeper.go
+++ b/zookeeper/zookeeper.go
@@ -89,6 +89,16 @@ func (r *ZkAdapter) Ping() error {
 	return nil
 }
 
+func (r *ZkAdapter) RemoveAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
+func (r *ZkAdapter) PostAttributes(service *bridge.Service) error {
+    // PLACEHOLDER: This method is yet to be implemented
+	return nil
+}
+
 func (r *ZkAdapter) Deregister(service *bridge.Service) error {
 	basePath := r.path + "/" + service.Name
 	if (r.path == "/") {


### PR DESCRIPTION
Consul currently does not support the storage of key value attributes passed in from registrator. 

This change stores the attributes for each service in the key/value store of consul when a service is first registered.

The attributes are only removed when the last instance of the service is removed from consul.