### PR TITLE
Add option to only register services which have SERVICE_NAME

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -273,10 +273,18 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		return nil
 	}
 
+	serviceName := mapDefault(metadata, "name", "")
+	if serviceName == "" {
+		if b.config.Explicit {
+			return nil
+		}
+		serviceName = defaultName
+	}
+
 	service := new(Service)
 	service.Origin = port
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
-	service.Name = mapDefault(metadata, "name", defaultName)
+	service.Name = serviceName
 	if isgroup && !metadataFromPort["name"] {
 		service.Name += "-" + port.ExposedPort
 	}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -22,6 +22,7 @@ type RegistryAdapter interface {
 type Config struct {
 	HostIp          string
 	Internal        bool
+	Explicit        bool
 	UseIpFromLabel  string
 	ForceTags       string
 	RefreshTtl      int

--- a/registrator.go
+++ b/registrator.go
@@ -20,6 +20,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
+var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
@@ -99,6 +100,7 @@ func main() {
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,
 		Internal:        *internal,
+		Explicit:        *explicit,
 		UseIpFromLabel:  *useIpFromLabel,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,


### PR DESCRIPTION
This adds the option "-explicit" which makes registrator ignore all
services which don't have a SERVICE_NAME label.