### PR TITLE
Include port optional

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -278,7 +278,9 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
 	if isgroup && !metadataFromPort["name"] {
-		service.Name += "-" + port.ExposedPort
+		if b.config.IncludePort {
+			service.Name += "-" + port.ExposedPort
+		}
 	}
 	var p int
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -277,10 +277,8 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.Origin = port
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
-	if isgroup && !metadataFromPort["name"] {
-		if b.config.IncludePort {
+	if b.config.IncludePort && isgroup && !metadataFromPort["name"] {
 			service.Name += "-" + port.ExposedPort
-		}
 	}
 	var p int
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -278,7 +278,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
 	if b.config.IncludePort && isgroup && !metadataFromPort["name"] {
-  	service.Name += "-" + port.ExposedPort
+		service.Name += "-" + port.ExposedPort
 	}
 	var p int
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -278,7 +278,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
 	service.Name = mapDefault(metadata, "name", defaultName)
 	if b.config.IncludePort && isgroup && !metadataFromPort["name"] {
-			service.Name += "-" + port.ExposedPort
+  	service.Name += "-" + port.ExposedPort
 	}
 	var p int
 

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -23,6 +23,7 @@ type Config struct {
 	HostIp          string
 	Internal        bool
 	UseIpFromLabel  string
+	IncludePort     bool
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int

--- a/registrator.go
+++ b/registrator.go
@@ -21,6 +21,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
+var includePort = flag.Bool("includePort", true, "Includes the port with the service name, eg \"service-1234\". Default true.")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -100,6 +101,7 @@ func main() {
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		UseIpFromLabel:  *useIpFromLabel,
+		IncludePort:     *includePort,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,


### PR DESCRIPTION
Including the port as part of the container is not optional. This makes a bit of an issue when looking up services by name.