### PR TITLE
Add go-sockaddr template support.

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/hashicorp/go-sockaddr/template"
 )
 
 var serviceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
@@ -202,7 +203,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 
 	// Extract configured host port mappings, relevant when using --net=host
 	for port, _ := range container.Config.ExposedPorts {
-		published := []dockerapi.PortBinding{ {"0.0.0.0", port.Port()}, }
+		published := []dockerapi.PortBinding{{"0.0.0.0", port.Port()}}
 		ports[string(port)] = servicePort(container, port, published)
 	}
 
@@ -246,6 +247,27 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	}
 }
 
+// parseSingleIPTemplate is used as a helper function to parse out a single IP
+// address from a config parameter.
+func parseSingleIPTemplate(ipTmpl string) (string, error) {
+	out, err := template.Parse(ipTmpl)
+	if err != nil {
+		log.Println("Unable to parse address template.")
+	}
+
+	ips := strings.Split(out, " ")
+	switch len(ips) {
+	case 0:
+		log.Println("No addresses found, please configure one.")
+		return false
+	case 1:
+		return ips[0], nil
+	default:
+		log.Println("Multiple addresses found, please configure one:", out)
+		return false
+	}
+}
+
 func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
@@ -263,7 +285,11 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 
 	if b.config.HostIp != "" {
-		port.HostIP = b.config.HostIp
+		ipStr, err := parseSingleIPTemplate(b.config.HostIp)
+		if err != nil {
+			log.Println("Config IP address resolution failed.", err)
+		}
+		port.HostIP = ipStr
 	}
 
 	metadata, metadataFromPort := serviceMetaData(container.Config, port.ExposedPort)
@@ -301,7 +327,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 				service.IP = containerIp
 			}
 			log.Println("using container IP " + service.IP + " from label '" +
-				b.config.UseIpFromLabel  + "'")
+				b.config.UseIpFromLabel + "'")
 		} else {
 			log.Println("Label '" + b.config.UseIpFromLabel +
 				"' not found in container configuration")


### PR DESCRIPTION
Force IP address used for registering services can use go-sockaddr/template: Allow go-sockaddr/template syntax to be used for ip address configuration. This allows registrator that can fetch its own address based on an interface name, network CIDR, address family from an actual RFC number, and many other possible schemes.