### PR TITLE
Add option to use consul catalog registration

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -13,6 +13,8 @@ import (
 
 const DefaultInterval = "10s"
 
+var ConsulRegMode string
+
 func init() {
 	f := new(Factory)
 	bridge.Register(f, "consul")
@@ -76,14 +78,38 @@ func (r *ConsulAdapter) Ping() error {
 }
 
 func (r *ConsulAdapter) Register(service *bridge.Service) error {
-	registration := new(consulapi.AgentServiceRegistration)
-	registration.ID = service.ID
-	registration.Name = service.Name
-	registration.Port = service.Port
-	registration.Tags = service.Tags
-	registration.Address = service.IP
-	registration.Check = r.buildCheck(service)
-	return r.client.Agent().ServiceRegister(registration)
+	if ConsulRegMode != "catalog" {
+		registration := new(consulapi.AgentServiceRegistration)
+		registration.ID = service.ID
+		registration.Name = service.Name
+		registration.Port = service.Port
+		registration.Tags = service.Tags
+		registration.Address = service.IP
+		registration.Check = r.buildCheck(service)
+
+		return r.client.Agent().ServiceRegister(registration)
+	} else {
+		agentService := new(consulapi.AgentService)
+		agentService.Service = service.Name
+		agentService.ID      = service.ID
+		agentService.Address = service.IP
+		agentService.Port    = service.Port
+		agentService.Tags    = service.Tags
+
+		hostname := strings.Split(service.ID, ":")[0]
+
+		catalogRegistration := new(consulapi.CatalogRegistration)
+		catalogRegistration.Node    = fmt.Sprintf("docker-%s", hostname)
+		catalogRegistration.ID      = service.ID
+		catalogRegistration.Address = hostname
+		catalogRegistration.Service = agentService
+
+		_, err := r.client.Catalog().Register(catalogRegistration, nil)
+		if err != nil {
+			log.Println("Error registering service:", err)
+		}
+		return err
+	}
 }
 
 func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServiceCheck {
@@ -126,7 +152,21 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 }
 
 func (r *ConsulAdapter) Deregister(service *bridge.Service) error {
-	return r.client.Agent().ServiceDeregister(service.ID)
+	if ConsulRegMode != "catalog" {
+		return r.client.Agent().ServiceDeregister(service.ID)
+	} else {
+		hostname := strings.Split(service.ID, ":")[0]
+
+		catalogDeregistration := new(consulapi.CatalogDeregistration)
+		catalogDeregistration.Node    = fmt.Sprintf("docker-%s", hostname)
+		catalogDeregistration.ServiceID = service.ID
+
+		_, err := r.client.Catalog().Deregister(catalogDeregistration, nil)
+		if err != nil {
+			log.Println("Error deregistering catalog:", err)
+		}
+		return err
+	}
 }
 
 func (r *ConsulAdapter) Refresh(service *bridge.Service) error {

--- a/registrator.go
+++ b/registrator.go
@@ -12,6 +12,7 @@ import (
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
 	"github.com/gliderlabs/registrator/bridge"
+	"github.com/gliderlabs/registrator/consul"
 )
 
 var Version string
@@ -29,6 +30,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var consulRegMode = flag.String("consulRegMode", "agent", "Consul registration mode \"agent\" or \"catalog\"")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -95,6 +97,12 @@ func main() {
 	if *deregister != "always" && *deregister != "on-success" {
 		assert(errors.New("-deregister must be \"always\" or \"on-success\""))
 	}
+	
+	if *consulRegMode != "agent" && *consulRegMode != "catalog" {
+		assert(errors.New("-consulRegMode must be \"agent\" or \"catalog\""))
+	}
+	
+	consul.ConsulRegMode = *consulRegMode
 
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:          *hostIp,


### PR DESCRIPTION
In environments where consul agent isn't running on docker host, this option allows for use of catalog registration (consulapi.CatalogRegistration) of services.

**Usage:**
Run registrator on a host that doesn't have docker agent

$ registrator --consulRegMode=catalog consul://<consul-server-ip>:8500
