### PR TITLE
Added an option (hostname-as-id) to set the hostname of the container as SERVICE_ID

### DIFF
--- a/bridge/types.go
+++ b/bridge/types.go
@@ -23,6 +23,7 @@ type Config struct {
 	HostIp          string
 	Internal        bool
 	Explicit        bool
+	HostnameAsId    bool
 	UseIpFromLabel  string
 	ForceTags       string
 	RefreshTtl      int

--- a/registrator.go
+++ b/registrator.go
@@ -21,6 +21,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
+var hostnameAsId = flag.Bool("hostname-as-id", false, "Use container hostname as SERVICE_ID")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
@@ -101,6 +102,7 @@ func main() {
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		Explicit:        *explicit,
+		HostnameAsId:    *hostnameAsId,
 		UseIpFromLabel:  *useIpFromLabel,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,


### PR DESCRIPTION
We had a usecase, where a service needed to access and modify it's own entry in Consul and finding it by the service container's hostname seemed like a viable solution.