### PR TITLE
Basic support for swarm mode services

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -3,9 +3,7 @@ package bridge
 import (
 	"errors"
 	"log"
-	"net"
 	"net/url"
-	"os"
 	"path"
 	"regexp"
 	"strconv"
@@ -13,17 +11,23 @@ import (
 	"sync"
 
 	dockerapi "github.com/fsouza/go-dockerclient"
+	"github.com/docker/docker/api/types/swarm"
 )
 
-var serviceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
+// format: node_id:container_name:port(:"upd")
+var containerServiceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
+
+// format: "swarm":swarm_service_id:node_id:port(:"upd")
+var swarmServiceIDPattern = regexp.MustCompile(`^swarm:(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
 
 type Bridge struct {
 	sync.Mutex
-	registry       RegistryAdapter
-	docker         *dockerapi.Client
-	services       map[string][]*Service
-	deadContainers map[string]*DeadContainer
-	config         Config
+	registry           RegistryAdapter
+	docker             *dockerapi.Client
+	containerServices  map[string][]*Service
+	deadContainers     map[string]*DeadContainer
+	swarmServices      map[string][]*Service
+	config             Config
 }
 
 func New(docker *dockerapi.Client, adapterUri string, config Config) (*Bridge, error) {
@@ -38,11 +42,12 @@ func New(docker *dockerapi.Client, adapterUri string, config Config) (*Bridge, e
 
 	log.Println("Using", uri.Scheme, "adapter:", uri)
 	return &Bridge{
-		docker:         docker,
-		config:         config,
-		registry:       factory.New(uri),
-		services:       make(map[string][]*Service),
-		deadContainers: make(map[string]*DeadContainer),
+		docker:            docker,
+		config:            config,
+		registry:          factory.New(uri),
+		containerServices: make(map[string][]*Service),
+		deadContainers:    make(map[string]*DeadContainer),
+		swarmServices:     make(map[string][]*Service),
 	}, nil
 }
 
@@ -75,14 +80,25 @@ func (b *Bridge) Refresh() {
 		}
 	}
 
-	for containerId, services := range b.services {
+	for containerId, services := range b.containerServices {
 		for _, service := range services {
 			err := b.registry.Refresh(service)
 			if err != nil {
-				log.Println("refresh failed:", service.ID, err)
+				log.Println("refresh container service failed:", containerId[:12], service.ID, err)
 				continue
 			}
-			log.Println("refreshed:", containerId[:12], service.ID)
+			log.Println("refreshed: container service ", containerId[:12], service.ID)
+		}
+	}
+
+	for swarmServiceId, services := range b.swarmServices {
+		for _, service := range services {
+			err := b.registry.Refresh(service)
+			if err != nil {
+				log.Println("refresh swarm service failed:", swarmServiceId[:12], service.ID, err)
+				continue
+			}
+			log.Println("refreshed: swarm service ", swarmServiceId[:12], service.ID)
 		}
 	}
 }
@@ -103,7 +119,7 @@ func (b *Bridge) Sync(quiet bool) {
 
 	// NOTE: This assumes reregistering will do the right thing, i.e. nothing..
 	for _, listing := range containers {
-		services := b.services[listing.ID]
+		services := b.containerServices[listing.ID]
 		if services == nil {
 			b.add(listing.ID, quiet)
 		} else {
@@ -116,6 +132,11 @@ func (b *Bridge) Sync(quiet bool) {
 		}
 	}
 
+	if b.config.SwarmMode && b.config.SwarmModeManager {
+	  // docker daemons "/services" api endpoint is available on swarm master nodes only.
+		b.syncSwarmModeVipServicesOnMasterNode()
+ 	}
+
 	// Clean up services that were registered previously, but aren't
 	// acknowledged within registrator
 	if b.config.Cleanup {
@@ -127,7 +148,7 @@ func (b *Bridge) Sync(quiet bool) {
 			log.Println("error listing nonExitedContainers, skipping sync", err)
 			return
 		}
-		for listingId, _ := range b.services {
+		for listingId, _ := range b.containerServices {
 			found := false
 			for _, container := range nonExitedContainers {
 				if listingId == container.ID {
@@ -151,18 +172,19 @@ func (b *Bridge) Sync(quiet bool) {
 
 	Outer:
 		for _, extService := range extServices {
-			matches := serviceIDPattern.FindStringSubmatch(extService.ID)
+			matches := containerServiceIDPattern.FindStringSubmatch(extService.ID)
+
 			if len(matches) != 3 {
 				// There's no way this was registered by us, so leave it
 				continue
 			}
-			serviceHostname := matches[1]
-			if serviceHostname != Hostname {
+			serviceNodeId := matches[1]
+			if serviceNodeId != b.config.NodeId {
 				// ignore because registered on a different host
 				continue
 			}
 			serviceContainerName := matches[2]
-			for _, listing := range b.services {
+			for _, listing := range b.containerServices {
 				for _, service := range listing {
 					if service.Name == extService.Name && serviceContainerName == service.Origin.container.Name[1:] {
 						continue Outer
@@ -182,11 +204,11 @@ func (b *Bridge) Sync(quiet bool) {
 
 func (b *Bridge) add(containerId string, quiet bool) {
 	if d := b.deadContainers[containerId]; d != nil {
-		b.services[containerId] = d.Services
+		b.containerServices[containerId] = d.Services
 		delete(b.deadContainers, containerId)
 	}
 
-	if b.services[containerId] != nil {
+	if b.containerServices[containerId] != nil {
 		log.Println("container, ", containerId[:12], ", already exists, ignoring")
 		// Alternatively, remove and readd or resubmit.
 		return
@@ -216,6 +238,29 @@ func (b *Bridge) add(containerId string, quiet bool) {
 		return
 	}
 
+	for _, port := range ports {
+		if b.config.Internal != true && port.HostPort == "" {
+			if !quiet {
+				log.Println("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
+			}
+			continue
+		}
+		service := b.newService(port, len(ports) > 1)
+		if service == nil {
+			if !quiet {
+				log.Println("ignored:", container.ID[:12], "service on port", port.ExposedPort)
+			}
+			continue
+		}
+		err := b.registry.Register(service)
+		if err != nil {
+			log.Println("register failed:", service, err)
+			continue
+		}
+		b.containerServices[container.ID] = append(b.containerServices[container.ID], service)
+		log.Println("added:", container.ID[:12], service.ID)
+	}
+
 	servicePorts := make(map[string]ServicePort)
 	for key, port := range ports {
 		if b.config.Internal != true && port.HostPort == "" {
@@ -241,7 +286,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 			log.Println("register failed:", service, err)
 			continue
 		}
-		b.services[container.ID] = append(b.services[container.ID], service)
+		b.containerServices[container.ID] = append(b.containerServices[container.ID], service)
 		log.Println("added:", container.ID[:12], service.ID)
 	}
 }
@@ -249,18 +294,6 @@ func (b *Bridge) add(containerId string, quiet bool) {
 func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	container := port.container
 	defaultName := strings.Split(path.Base(container.Config.Image), ":")[0]
-
-	// not sure about this logic. kind of want to remove it.
-	hostname := Hostname
-	if hostname == "" {
-		hostname = port.HostIP
-	}
-	if port.HostIP == "0.0.0.0" {
-		ip, err := net.ResolveIPAddr("ip", hostname)
-		if err == nil {
-			port.HostIP = ip.String()
-		}
-	}
 
 	if b.config.HostIp != "" {
 		port.HostIP = b.config.HostIp
@@ -276,6 +309,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	serviceName := mapDefault(metadata, "name", "")
 	if serviceName == "" {
 		if b.config.Explicit {
+			log.Printf("ignored: container service without explicit naming %s", container.ID[:12])
 			return nil
 		}
 		serviceName = defaultName
@@ -283,8 +317,18 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 
 	service := new(Service)
 	service.Origin = port
-	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort
-	service.Name = serviceName
+
+	// consider swarm mode
+	if swarmServiceName, ok := port.container.Config.Labels["com.docker.swarm.service.name"]; ok {
+		// swarm mode has concept of services
+		service.Name = mapDefault(metadata, "name", swarmServiceName)
+	} else {
+		service.Name = mapDefault(metadata, "name", defaultName)
+	}
+
+	// must match containerServiceIDPattern
+	service.ID = b.config.NodeId + ":" + container.Name[1:] + ":" + port.ExposedPort
+
 	if isgroup && !metadataFromPort["name"] {
 		service.Name += "-" + port.ExposedPort
 	}
@@ -355,6 +399,340 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	return service
 }
 
+/*
+ * Find registered swarm mode vip services by filtering all registered services from registration backend.
+ * This is done by pattern matching the service ids.
+ * Returns a map with the id of the swarm service as key and its appropriate registered services as value.
+ */
+func (b *Bridge) findRegisteredSwarmServices(registeredServices []*Service) map[string][]*Service {
+	result := make(map[string][]*Service)
+	for _, registeredService := range registeredServices {
+
+		matches := swarmServiceIDPattern.FindStringSubmatch(registeredService.ID)
+
+		if len(matches) != 3 {
+			// this service wasn't registered as swarm mode service so we have to filter it here
+			continue
+		}
+
+		nodeId := matches[2]
+
+		if nodeId != b.config.NodeId {
+			// we can't deregister services that were registered on a different node
+			continue
+		}
+
+		swarmServiceId := matches[1]
+
+		if services, ok := result[swarmServiceId]; ok {
+			services = append(services, registeredService)
+			result[swarmServiceId] = services
+		} else {
+			services := make([]*Service, 0)
+			services = append(services, registeredService)
+			result[swarmServiceId] = services
+		}
+	}
+
+	return result
+}
+
+/*
+ * Iterates over all registered swarm mode vip services from registration backend and calls the given condition function.
+ * If condition returns true it deregisters the appropriate service from the registration backend.
+ */
+func (b *Bridge) deregisterRegisteredSwarmServices(condition func(swarmServiceId string, registeredService *Service) bool) {
+	registeredServices, err := b.registry.Services()
+	if err != nil {
+		log.Fatal("cant get registered services: ", err)
+		return
+	}
+
+	for swarmServiceId, registeredServices := range b.findRegisteredSwarmServices(registeredServices) {
+		for _, registeredService := range registeredServices {
+			if condition(swarmServiceId, registeredService) {
+				b.registry.Deregister(registeredService)
+				// remove swarm service from cache
+				delete(b.swarmServices, swarmServiceId)
+			}
+		}
+	}
+}
+
+/*
+ * Syncs docker swarm mode vip services with registration backend. For vip/ingress services each
+ * swarm node is part of the routing mesh so we would have to register a service for each node.
+ * Sadly this is not possible atm for worker nodes as they don't provide the needed /services endpoint
+ * nor it is possible to receive service events via the docker remote api.
+ */
+func (b *Bridge) syncSwarmModeVipServicesOnMasterNode() {
+	log.Println("Syncing swarm mode vip services")
+	// get existing swarm services
+	servicefilters := map[string][]string{}
+	swarmServices, err := b.docker.ListServices(dockerapi.ListServicesOptions{Filters: servicefilters})
+	if err != nil {
+		log.Println("error listing swarm mode services:", err)
+	}
+
+	swarmServicesMap := make(map[string]swarm.Service)
+
+	for _, swarmService := range swarmServices {
+		swarmServicesMap[swarmService.ID] = swarmService
+		b.registerSwarmService(swarmService)
+	}
+
+	deregisterCondition := func(swarmServiceId string, registeredService *Service) bool {
+		if swarmService, ok := swarmServicesMap[swarmServiceId]; ok {
+			mode := swarmService.Spec.EndpointSpec.Mode
+			if b.config.ReplicasAware && *swarmService.Spec.Mode.Replicated.Replicas < uint64(1) {
+				log.Printf("removed: swarm vip service without replicas %s:%d ", registeredService.Name, registeredService.Port)
+				return true
+			} else if mode != swarm.ResolutionModeVIP {
+				log.Printf("removed: swarm vip service %s:%d", registeredService.Name, registeredService.Port)
+				return true
+			} else {
+				return false
+			}
+		}	else {
+			log.Printf("removed: swarm vip service not running anymore %s:%d", registeredService.Name, registeredService.Port)
+			return true
+		}
+	}
+
+	b.deregisterRegisteredSwarmServices(deregisterCondition)
+}
+
+func (b *Bridge) RegisterSwarmServiceById(aSwarmServiceId string) (*swarm.Service, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	swarmService, err := b.docker.InspectService(aSwarmServiceId)
+
+	if err == nil {
+		b.registerSwarmService(*swarmService)
+		return swarmService, err
+	} else {
+		return swarmService, err
+	}
+}
+
+func (b *Bridge) DeregisterSwarmServiceById(aSwarmServiceId string) {
+	b.Lock()
+	defer b.Unlock()
+
+	deregisterCondition := func(swarmServiceId string, registeredService *Service) bool {
+		if swarmServiceId == aSwarmServiceId {
+			log.Printf("removed: swarm vip service %s:%d", registeredService.Name, registeredService.Port)
+			return true
+		} else {
+			return false
+		}
+	}
+
+	b.deregisterRegisteredSwarmServices(deregisterCondition)
+}
+
+func (b *Bridge) UpdateSwarmServiceById(aSwarmServiceId string) {
+	b.Lock()
+	defer b.Unlock()
+
+	// registers service eventually (because replicas>0) if currently not registered (because replicas=0)
+	swarmService, err := b.RegisterSwarmServiceById(aSwarmServiceId)
+
+	if err != nil {
+		log.Printf("can't register swarm service by id: ", aSwarmServiceId)
+		return
+	}
+
+	deregisterCondition := func(swarmServiceId string, registeredService *Service) bool {
+		mode := swarmService.Spec.EndpointSpec.Mode
+		if swarmServiceId == aSwarmServiceId && b.config.ReplicasAware && *swarmService.Spec.Mode.Replicated.Replicas < uint64(1) {
+			log.Printf("removed: swarm vip service without replicas %s:%d ", registeredService.Name, registeredService.Port)
+			return true
+		} else if mode != swarm.ResolutionModeVIP {
+			log.Printf("removed: swarm vip service %s:%d ", registeredService.Name, registeredService.Port)
+			return true
+		} else {
+			return false
+		}
+	}
+
+	b.deregisterRegisteredSwarmServices(deregisterCondition)
+}
+
+func (b *Bridge) registerSwarmService(swarmService swarm.Service) {
+	if swarmService.Spec.EndpointSpec != nil {
+		mode := swarmService.Spec.EndpointSpec.Mode
+		// DNSrr service will be handled as container service (see Sync())
+		if mode == swarm.ResolutionModeVIP {
+			if (len(swarmService.Endpoint.VirtualIPs) > 0) {
+				if b.config.ReplicasAware {
+					if *swarmService.Spec.Mode.Replicated.Replicas > uint64(0) {
+						b.registerSwarmVipServices(swarmService)
+					}
+				} else {
+					b.registerSwarmVipServices(swarmService)
+				}
+			}
+		}
+	}
+}
+
+// there are two types of endpoints VIP and DNS rr based
+// DNS rr happens implicitly by registering multiple services with the same name
+// so that no extra effort is required
+// in case of VIP based services, user specifies the published ports
+// which are equivalent of docker port binding, but works differently
+// swarm mode provides ingress network, where services are load-balanced
+// behind VIP address. From inside network (if there any) perspective
+// only one service is need, with swarm mode assigned VIP address.
+// From outside perspective, every docker host IP address becomes an entry point
+// for load-balancer, so published ports shall be registered for each docker host
+func (b *Bridge) registerSwarmVipServices(swarmService swarm.Service) {
+
+	// if internal, register the internal VIP services
+	if b.config.Internal {
+		for _, vip := range swarmService.Endpoint.VirtualIPs {
+			if network, err := b.docker.NetworkInfo(vip.NetworkID); err != nil {
+				log.Println("unable to inspect network while evaluating VIPs for service:", swarmService.Spec.Name, err)
+			} else {
+				// no point to publish docker swarm internal ingress network VIP
+				if network.Name != "ingress" && len(vip.Addr) > 0 && strings.Contains(vip.Addr, "/") {
+					vipAddr := strings.Split(vip.Addr, "/")[0]
+					if len(swarmService.Endpoint.Ports) > 0 {
+						b.registerSwarmVipServicePorts(swarmService, true, vipAddr)
+					}
+				}
+			}
+		}
+	} else {
+		// if there is no published ports, no point to register it out side
+		if len(swarmService.Endpoint.Ports) > 0 {
+			b.registerSwarmVipServicePorts(swarmService, false, b.config.HostIp)
+		}
+	}
+}
+
+/*
+ * Registers each port of a swarm service as a single service in the registration backend.
+ */
+func (b *Bridge) registerSwarmVipServicePorts(swarmService swarm.Service, inside bool, vip string) {
+
+	envMap := envToMap(swarmService.Spec.TaskTemplate.ContainerSpec.Env)
+	labelsMap := swarmService.Spec.TaskTemplate.ContainerSpec.Labels
+
+	f := func(key string) bool {
+		return strings.HasPrefix(key, "SERVICE_")
+	}
+
+	joinedMap := make(map[string]string)
+	joinMaps(labelsMap, joinedMap, f)
+	joinMaps(envMap, joinedMap, f)
+
+	portsMetadata := make(map[int]map[string]string)
+
+	for key, value := range joinedMap {
+		key = strings.ToLower(strings.TrimPrefix(key, "SERVICE_"))
+		portkey := strings.SplitN(key, "_", 2)
+		p, err := strconv.Atoi(portkey[0])
+		if err == nil && len(portkey) > 1 {
+			if portMeta, ok := portsMetadata[p]; ok {
+				portMeta[portkey[1]] = value
+			}	else {
+				portsMetadata[p] = make(map[string]string)
+				portsMetadata[p][portkey[1]] = value
+			}
+		}
+	}
+
+	services := make([]*Service, 0)
+
+	for _, port := range swarmService.Endpoint.Ports {
+
+		// If the service port is published in host mode and there isn't a published port configured docker will
+		// auto assign a random port. This port is not available via service inspection because it may
+		// differ for each replica/host. So we can't register the service here.
+		// Instead the appropriate container has a published port defined and will be registered as normal
+		// non-swarm service then. See Sync() and Add().
+		if port.PublishMode == "host" && port.PublishedPort == 0 {
+			continue
+		}
+
+		var portNum uint32
+		if portNum = port.PublishedPort; inside {
+			// inside port is not translated to published port
+			portNum = port.TargetPort
+		}
+
+		serviceName := ""
+		targetPort := int(port.TargetPort)
+		portMeta, ok := portsMetadata[targetPort]
+
+		if ok {
+		  if portName, ok := portMeta["name"]; ok {
+			  serviceName = portName
+				delete(portMeta, "name")
+			}
+		} else {
+			if b.config.Explicit {
+				log.Printf("ignored: swarm vip service has no explicit naming %s", swarmService.Spec.Name)
+				continue
+			}
+			serviceName = swarmService.Spec.Name
+			portMeta = make(map[string]string)
+		}
+
+		// must match swarmServiceIDPattern
+		serviceID := "swarm:" + swarmService.ID + ":" + b.config.NodeId + ":" + strconv.Itoa(targetPort)
+
+		services = append(services, b.registerSwarmVipServicePort(serviceID, serviceName, portMeta, inside, vip, int(portNum), port.Protocol))
+	}
+
+	// cache registered swarm services
+	b.swarmServices[swarmService.ID] = services
+
+  log.Printf("registered %d services for swarm service %s ", len(services), swarmService.ID)
+}
+
+/*
+ * Registers a single port of a swarm vip service as service in the registration backend.
+ */
+func (b *Bridge) registerSwarmVipServicePort(serviceID string, serviceName string, metadata map[string]string, inside bool, vip string, port int, protocol swarm.PortConfigProtocol) *Service {
+
+	var tag string
+	if tag = "vip-outside"; inside {
+		tag = "vip-inside"
+	}
+
+	service := new(Service)
+
+	service.ID = serviceID
+	service.Name = serviceName
+
+	// tag it for convenience
+	if protocol != swarm.PortConfigProtocolTCP {
+		service.Tags = combineTags(
+			mapDefault(metadata, "tags", ""), b.config.ForceTags, tag, string(protocol))
+	} else {
+		service.Tags = combineTags(
+			mapDefault(metadata, "tags", ""), b.config.ForceTags, tag)
+	}
+
+	delete(metadata, "tags")
+	service.IP = vip
+	service.Port = port
+	service.Attrs = metadata
+
+	err := b.registry.Register(service)
+	if err != nil {
+		log.Printf("register failed:", service.Name, err)
+	}
+
+	log.Printf("added: swarm vip service %s:%d", service.Name, service.Port)
+
+	return service
+}
+
 func (b *Bridge) remove(containerId string, deregister bool) {
 	b.Lock()
 	defer b.Unlock()
@@ -370,16 +748,16 @@ func (b *Bridge) remove(containerId string, deregister bool) {
 				log.Println("removed:", containerId[:12], service.ID)
 			}
 		}
-		deregisterAll(b.services[containerId])
+		deregisterAll(b.containerServices[containerId])
 		if d := b.deadContainers[containerId]; d != nil {
 			deregisterAll(d.Services)
 			delete(b.deadContainers, containerId)
 		}
-	} else if b.config.RefreshTtl != 0 && b.services[containerId] != nil {
+	} else if b.config.RefreshTtl != 0 && b.containerServices[containerId] != nil {
 		// need to stop the refreshing, but can't delete it yet
-		b.deadContainers[containerId] = &DeadContainer{b.config.RefreshTtl, b.services[containerId]}
+		b.deadContainers[containerId] = &DeadContainer{b.config.RefreshTtl, b.containerServices[containerId]}
 	}
-	delete(b.services, containerId)
+	delete(b.containerServices, containerId)
 }
 
 // bit set on ExitCode if it represents an exit via a signal
@@ -411,12 +789,4 @@ func (b *Bridge) shouldRemove(containerId string) bool {
 		return true
 	}
 	return false
-}
-
-var Hostname string
-
-func init() {
-	// It's ok for Hostname to ultimately be an empty string
-	// An empty string will fall back to trying to make a best guess
-	Hostname, _ = os.Hostname()
 }

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -20,15 +20,19 @@ type RegistryAdapter interface {
 }
 
 type Config struct {
-	HostIp          string
-	Internal        bool
-	Explicit        bool
-	UseIpFromLabel  string
-	ForceTags       string
-	RefreshTtl      int
-	RefreshInterval int
-	DeregisterCheck string
-	Cleanup         bool
+	NodeId           string
+	HostIp           string
+	Internal         bool
+	Explicit         bool
+	UseIpFromLabel   string
+	ForceTags        string
+	RefreshTtl       int
+	RefreshInterval  int
+	DeregisterCheck  string
+	Cleanup          bool
+	SwarmMode        bool
+	SwarmModeManager bool
+	ReplicasAware    bool
 }
 
 type Service struct {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -84,6 +84,26 @@ func serviceMetaData(config *dockerapi.Config, port string) (map[string]string, 
 	return metadata, metadataFromPort
 }
 
+func envToMap(lines []string) (map[string]string) {
+	result := make(map[string]string)
+	for _, line := range lines {
+		kvp := strings.SplitN(line, "=", 2)
+		if len(kvp) > 1 {
+			result[kvp[0]] = kvp[1]
+		}
+	}
+	return result
+}
+
+func joinMaps(src map[string]string, dst map[string]string, filter func(key string)bool) (map[string]string) {
+	for key, value := range src {
+		if filter(key) {
+			dst[key] = value
+		}
+	}
+	return dst
+}
+
 func servicePort(container *dockerapi.Container, port dockerapi.Port, published []dockerapi.PortBinding) ServicePort {
 	var hp, hip, ep, ept, eip, nm string
 	if len(published) > 0 {

--- a/bridge/util_test.go
+++ b/bridge/util_test.go
@@ -57,3 +57,21 @@ func TestEscapedComma(t *testing.T) {
 		assert.EqualValues(t, c.Expected, results)
 	}
 }
+
+func TestEnvToMap(t *testing.T) {
+	env := []string{
+		"",
+		"",
+	}
+	result := envToMap(env)
+	assert.Equal(t, len(result), 0)
+
+	env = []string{
+		"key1=value1",
+		"key2=value2",
+	}
+	result = envToMap(env)
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, result["key1"], "value1")
+	assert.Equal(t, result["key2"], "value2")
+}

--- a/registrator.go
+++ b/registrator.go
@@ -12,6 +12,7 @@ import (
 	dockerapi "github.com/fsouza/go-dockerclient"
 	"github.com/gliderlabs/pkg/usage"
 	"github.com/gliderlabs/registrator/bridge"
+	"github.com/docker/docker/api/types/swarm"
 )
 
 var Version string
@@ -20,7 +21,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
-var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
+var explicit = flag.Bool("explicit", false, "Only register services which have SERVICE_NAME label set")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
@@ -97,16 +98,55 @@ func main() {
 		assert(errors.New("-deregister must be \"always\" or \"on-success\""))
 	}
 
+	// use docker info to determine node id that will be used as prefix to service id
+	dockerInfo, err := docker.Info()
+	assert(err)
+
+	nodeId := new(string)
+	// docker host name normally is hostname
+	*nodeId = dockerInfo.Name
+
+	swarmMode := false
+	swarmModeManager := false
+
+	if dockerInfo.Swarm.LocalNodeState != swarm.LocalNodeStateInactive {
+		swarmMode = true
+
+		for _, remoteManager := range dockerInfo.Swarm.RemoteManagers {
+			if dockerInfo.Swarm.NodeID == remoteManager.NodeID {
+				swarmModeManager = true
+			}
+		}
+
+		if *hostIp == "" {
+			// in case of swarm mode, docker host has information about ip
+			// although it won't be always useful, we can use it if not provided by user
+			*hostIp = dockerInfo.Swarm.NodeAddr
+		}
+
+		log.Printf("Docker host in Swarm Mode: %s (%s) isManager: %v", *nodeId, *hostIp, swarmModeManager)
+
+		if !swarmModeManager {
+			log.Printf("Syncing swarm mode vip/ingress routed services on worker node is not implemented yet")
+		}
+	} else {
+		log.Printf("Docker host: %s (%s)", *nodeId, *hostIp)
+	}
+
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
-		HostIp:          *hostIp,
-		Internal:        *internal,
-		Explicit:        *explicit,
-		UseIpFromLabel:  *useIpFromLabel,
-		ForceTags:       *forceTags,
-		RefreshTtl:      *refreshTtl,
-		RefreshInterval: *refreshInterval,
-		DeregisterCheck: *deregister,
-		Cleanup:         *cleanup,
+		NodeId:           *nodeId,
+		HostIp:           *hostIp,
+		Internal:         *internal,
+		Explicit:         *explicit,
+		UseIpFromLabel:   *useIpFromLabel,
+		ForceTags:        *forceTags,
+		RefreshTtl:       *refreshTtl,
+		RefreshInterval:  *refreshInterval,
+		DeregisterCheck:  *deregister,
+		Cleanup:          *cleanup,
+		SwarmMode:        swarmMode,
+		SwarmModeManager: swarmModeManager,
+		ReplicasAware:    true,
 	})
 
 	assert(err)
@@ -171,11 +211,41 @@ func main() {
 
 	// Process Docker events
 	for msg := range events {
-		switch msg.Status {
-		case "start":
-			go b.Add(msg.ID)
-		case "die":
-			go b.RemoveOnExit(msg.ID)
+		switch msg.Type {
+			case "container": {
+				switch msg.Action {
+					case "start": {
+						log.Printf("event: container %s started", msg.Actor.ID)
+						go b.Add(msg.Actor.ID)
+					}
+					case "die": {
+						log.Printf("event: container %s died", msg.Actor.ID)
+						go b.RemoveOnExit(msg.Actor.ID)
+					}
+					default: {
+						log.Printf("event: %s %s %s", msg.Type, msg.Action, msg.Actor.ID)
+					}
+				}
+			}
+			case "service": {
+				switch msg.Action {
+					case "create": {
+						log.Printf("event: swarm service %s created", msg.Actor.ID)
+						go b.RegisterSwarmServiceById(msg.Actor.ID)
+					}
+					case "update": {
+						log.Printf("event: swarm service %s updated", msg.Actor.ID)
+						go b.UpdateSwarmServiceById(msg.Actor.ID)
+					}
+					case "remove": {
+						log.Printf("event: swarm service %s removed", msg.Actor.ID)
+						go b.DeregisterSwarmServiceById(msg.Actor.ID)
+					}
+					default: {
+						log.Printf("event: %s %s %s", msg.Type, msg.Action, msg.Actor.ID)
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Combines the efforts of https://github.com/gliderlabs/registrator/pull/476 and https://github.com/gliderlabs/registrator/pull/520 for supporting swarm mode services.

This PR implements registration of swarm mode vip services with one limitation: Ingress routed services (routed via routing mesh) will be registered on swarm manager nodes only. On worker nodes this is not possible at the moment due to the fact that swarm services can't be inspected via worker nodes remote API. Probably this isn't a big limitation as long as you have enough manager nodes within the swarm.

One approach to this problem would be to replicate the registered services from the registry to the worker nodes by polling. But at least with the current consul backend implementation it wouldn't work because it delivers the services of the own node only.

@progrium Please review. Thanks!