### PR TITLE
Consul check documentation improvement

### DIFF
--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -101,6 +101,15 @@ By default when a service is registered against Consul, the state is set to "cri
 SERVICE_CHECK_INITIAL_STATUS=passing
 ```
 
+### Consul Critical Service Deregistration
+
+Consul can deregister a service if the check is in the critical state for more than a configurable amount of time.
+If enabled this should be much longer than any expected recoverable outage.
+
+```bash
+SERVICE_CHECK_DEREGISTER_AFTER=10m
+```
+
 ## Consul KV
 
 	consulkv://<address>:<port>/<prefix>

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -24,6 +24,8 @@ When using the `consul-tls` scheme, registrator communicates with Consul through
  * `CONSUL_TLSCERT` : Certificate file location
  * `CONSUL_TLSKEY` : Key location
 
+For more information on the Consul check parameters below, see the [API documentation](https://www.consul.io/api/agent/check.html#register-check).
+
 ### Consul HTTP Check
 
 This feature is only available when using Consul 0.5 or newer. Containers

--- a/docs/user/services.md
+++ b/docs/user/services.md
@@ -97,8 +97,8 @@ support them. In fact, currently Consul supports tags and none support
 attributes.
 
 Attributes can also be used by backends for registry specific features, not just
-generic metadata. For example, Consul uses them for specifying HTTP health
-checks.
+generic metadata. For example, Consul uses them for [specifying HTTP health
+checks](./backends.md#consul).
 
 ## Unique ID
 


### PR DESCRIPTION
I had trouble finding a list of the available `SERVICE_CHECK_*` environment variables, so I added a link from where I expected them to be. I also added a check parameter that was missing from the docs.