### PR TITLE
too many arguments in call to r.DecodeBytes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,13 @@ ENTRYPOINT ["/bin/registrator"]
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk --no-cache add -t build-deps build-base go git \
 	&& apk --no-cache add ca-certificates \
-	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
+        && go get -u github.com/ugorji/go/codec/codecgen \
+	&& mkdir /go/src/github.com/coreos \
+	&& git clone https://github.com/coreos/go-etcd.git /go/src/github.com/coreos/go-etcd  \
+        && cd /go/src/github.com/coreos/go-etcd/etcd \
+        && /go/bin/codecgen -d 1978 -o response.generated.go response.go \
+	&& cd /go/src/github.com/gliderlabs/registrator \
   && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,6 +5,11 @@ ENV GOPATH /go
 RUN apk --no-cache add build-base go git ca-certificates
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
+  && go get -u github.com/ugorji/go/codec/codecgen \
+  && mkdir /go/src/github.com/coreos \
+  && git clone https://github.com/coreos/go-etcd.git /go/src/github.com/coreos/go-etcd  \
+  && cd /go/src/github.com/coreos/go-etcd/etcd \
+  && /go/bin/codecgen -d 1978 -o response.generated.go response.go \
   && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator


### PR DESCRIPTION
go-etcd is depricated, so will not receive fixes required to compile with recent breaking changes in ugorji/go

re :
https://github.com/gliderlabs/registrator/issues/591
https://github.com/coreos/go-etcd/pull/250