### PR TITLE
Added support for useIpFromNetwork

### DIFF
--- a/bridge/types.go
+++ b/bridge/types.go
@@ -20,15 +20,16 @@ type RegistryAdapter interface {
 }
 
 type Config struct {
-	HostIp          string
-	Internal        bool
-	Explicit        bool
-	UseIpFromLabel  string
-	ForceTags       string
-	RefreshTtl      int
-	RefreshInterval int
-	DeregisterCheck string
-	Cleanup         bool
+	HostIp           string
+	Internal         bool
+	Explicit         bool
+	UseIpFromNetwork string
+	UseIpFromLabel   string
+	ForceTags        string
+	RefreshTtl       int
+	RefreshInterval  int
+	DeregisterCheck  string
+	Cleanup          bool
 }
 
 type Service struct {

--- a/registrator.go
+++ b/registrator.go
@@ -22,6 +22,7 @@ var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
+var useIpFromNetwork = flag.String("useIpFromNetwork", "", "Use IP that is assigned on to a containers network")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -98,15 +99,16 @@ func main() {
 	}
 
 	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
-		HostIp:          *hostIp,
-		Internal:        *internal,
-		Explicit:        *explicit,
-		UseIpFromLabel:  *useIpFromLabel,
-		ForceTags:       *forceTags,
-		RefreshTtl:      *refreshTtl,
-		RefreshInterval: *refreshInterval,
-		DeregisterCheck: *deregister,
-		Cleanup:         *cleanup,
+		HostIp:           *hostIp,
+		Internal:         *internal,
+		Explicit:         *explicit,
+		UseIpFromNetwork: *useIpFromNetwork,
+		UseIpFromLabel:   *useIpFromLabel,
+		ForceTags:        *forceTags,
+		RefreshTtl:       *refreshTtl,
+		RefreshInterval:  *refreshInterval,
+		DeregisterCheck:  *deregister,
+		Cleanup:          *cleanup,
 	})
 
 	assert(err)


### PR DESCRIPTION
This adds a flag that allows users to specify a network that they want registrator to use when resolving service ip.

the flag is `useIpFromNetwork` and takes the string name of the network to use.

I realize that there are similar PR's open for this but most of them seem a bit dead.