### PR TITLE
Populate Consul's ServiceMeta using service.Attrs

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"strings"
-	"strconv"
 	"os"
+	"strconv"
+	"strings"
+
 	"github.com/gliderlabs/registrator/bridge"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-cleanhttp"
@@ -34,16 +35,16 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	if uri.Scheme == "consul-unix" {
 		config.Address = strings.TrimPrefix(uri.String(), "consul-")
 	} else if uri.Scheme == "consul-tls" {
-	        tlsConfigDesc := &consulapi.TLSConfig {
-			  Address: uri.Host,
-			  CAFile: os.Getenv("CONSUL_CACERT"),
-  			  CertFile: os.Getenv("CONSUL_TLSCERT"),
-  			  KeyFile: os.Getenv("CONSUL_TLSKEY"),
-			  InsecureSkipVerify: false,
+		tlsConfigDesc := &consulapi.TLSConfig{
+			Address:            uri.Host,
+			CAFile:             os.Getenv("CONSUL_CACERT"),
+			CertFile:           os.Getenv("CONSUL_TLSCERT"),
+			KeyFile:            os.Getenv("CONSUL_TLSKEY"),
+			InsecureSkipVerify: false,
 		}
 		tlsConfig, err := consulapi.SetupTLSConfig(tlsConfigDesc)
 		if err != nil {
-		   log.Fatal("Cannot set up Consul TLSConfig", err)
+			log.Fatal("Cannot set up Consul TLSConfig", err)
 		}
 		config.Scheme = "https"
 		transport := cleanhttp.DefaultPooledTransport()
@@ -84,6 +85,7 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 	registration.Tags = service.Tags
 	registration.Address = service.IP
 	registration.Check = r.buildCheck(service)
+	registration.Meta = service.Attrs
 	return r.client.Agent().ServiceRegister(registration)
 }
 

--- a/docs/user/services.md
+++ b/docs/user/services.md
@@ -53,7 +53,7 @@ These can be implicitly set from the Dockerfile or explicitly set with `docker r
 You can also tell Registrator to ignore a container by setting a
 label or environment variable for `SERVICE_IGNORE`.
 
-If you need to ignore individual service on some container, you can use 
+If you need to ignore individual service on some container, you can use
 `SERVICE_<port>_IGNORE=true`.
 
 ## Service Name
@@ -93,8 +93,10 @@ Docker-assigned internal IP of the container**.
 ## Tags and Attributes
 
 Tags and attributes are extra metadata fields for services. Not all backends
-support them. In fact, currently Consul supports tags and none support
-attributes.
+support them. In fact, currently Consul supports tags and more recently as of
+version 1.0.7, it added support for attributes as well in the form of
+[KV metadata](https://www.consul.io/api/agent/service.html#meta) but no other
+backend supports attributes.
 
 Attributes can also be used by backends for registry specific features, not just
 generic metadata. For example, Consul uses them for [specifying HTTP health


### PR DESCRIPTION
Populates Consul's [ServiceMeta](https://www.consul.io/api/agent/service.html#meta) field with Registrator's [Attr](http://gliderlabs.github.io/registrator/latest/user/services/) so that we can query a service with additional attributes bypassing the need to use a key/value store:

Example:

Setting the following container's environment variables to the following:
- SERVICE_PROTOCOL="http"
- SERVICE_TYPE="service"

would result in: (Note the ServiceMeta field).

```json
[{
	"ID": "26596b52-0d61-ee5c-bac2-52d66b8ee8fc",
	"Node": "test-node",
	"Address": "xxx",
	"Datacenter": "eu-west-1",
	"TaggedAddresses": {
		"lan": "xxx",
		"wan": "xxx"
	},
	"NodeMeta": {
		"consul-network-segment": ""
	},
	"ServiceID": "xxx",
	"ServiceName": "users",
	"ServiceTags": [
		"environment=devel",
		"zone=eu-west-1a"
	],
	"ServiceAddress": "xxx",
	"ServiceMeta": {
		"check_interval": "15s",
		"check_tcp": "true",
		"check_timeout": "3s",
		"protocol": "http",
		"type": "service"
	},
	"ServicePort": 16234,
	"ServiceEnableTagOverride": false,
	"CreateIndex": 4075434,
	"ModifyIndex": 4075434
}]
```

References https://github.com/gliderlabs/registrator/issues/619