### PR TITLE
Properly use CircleCI 2.0 for builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,9 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: gliderlabs/ci:build-2
-        command: ["/bin/bash"]
-    working_directory: /go/src/github.com/gliderlabs/registrator
+    machine: true
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           command: make circleci
       - run:
@@ -18,7 +14,7 @@ jobs:
       - deploy:
           name: Deploy website
           command: |
-            if is-branch "master"; then
+            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
               mv .dockerignore .dockerignore-repo
               eval $(docker run gliderlabs/pagebuilder circleci-cmd)
               mv .dockerignore-repo .dockerignore
@@ -26,6 +22,6 @@ jobs:
       - deploy:
           name: Deploy beta channel
           command: |
-            if is-branch "release"; then
+            if [[ "$CIRCLE_BRANCH" == "release" ]]; then
               make release
             fi


### PR DESCRIPTION
The switch to circleci 2.0 completely broke page builds - amongst other things - as the docker build type doesn't support docker volumes.

Moving to the machine build type allows us to use docker volumes, though we lose the ability to use helper functions.