### PR TITLE
Use alpine:3.7 instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk --no-cache add -t build-deps build-base go git curl \
 	&& rm -rf /go \
 	&& apk del --purge build-deps
 
-FROM scratch
+FROM alpine:3.7
 COPY --from=builder /bin/registrator /bin/registrator
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/bin/registrator"]


### PR DESCRIPTION
The multistage build failed with "scratch" as the base image. This is because, based from [here](https://stackoverflow.com/questions/49535379/binary-compiled-in-prestage-doesnt-work-in-scratch-container), scratch is an explicitly empty image. It has no shared object, it has no runtime libraries.

The following error was observed when running registrator in docker.

```standard_init_linux.go:190: exec user process caused "no such file or directory"```

The proposed solution for now is to use alpine:3.7 instead of scratch. This fixes the above problem.
