### PR TITLE
Use AgentServiceCheck.Args when registering Consul script/container checks

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -105,9 +105,9 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 			check.Timeout = timeout
 		}
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
-		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
+		check.Args = strings.Split(fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd), " ")
 	} else if script := service.Attrs["check_script"]; script != "" {
-		check.Script = r.interpolateService(script, service)
+		check.Args = strings.Split(r.interpolateService(script, service), " ")
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
@@ -118,7 +118,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else {
 		return nil
 	}
-	if check.Script != "" || check.HTTP != "" || check.TCP != "" {
+	if len(check.Args) > 0 || check.HTTP != "" || check.TCP != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {


### PR DESCRIPTION
Consul [recently replaced][1] the Script field from AgentServiceCheck with an Args string slice.

This updates the creation of these checks to use the Args field.

[1]: https://github.com/hashicorp/consul/commit/b73323aa429f6edcfdff3b951774ca6f296f2bc5#diff-4f360b6361d9900f98e2f244a3411bc4