### PR TITLE
Fix Dockerfile.dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --no-cache add -t build-deps build-base go git curl \
 	&& curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
-  && git config --global http.https://gopkg.in.followRedirects true \
+	&& git config --global http.https://gopkg.in.followRedirects true \
 	&& dep ensure \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,13 @@
-FROM alpine:3.5
+FROM alpine:3.7
 CMD ["/bin/registrator"]
 
-ENV GOPATH /go
-RUN apk --no-cache add build-base go git ca-certificates
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN cd /go/src/github.com/gliderlabs/registrator \
-  && git config --global http.https://gopkg.in.followRedirects true \
-	&& go get \
+RUN apk --no-cache add -t build-deps build-base go git curl \
+	&& apk --no-cache add ca-certificates \
+	&& export GOPATH=/go && mkdir -p /go/bin && export PATH=$PATH:/go/bin \
+	&& curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
+	&& cd /go/src/github.com/gliderlabs/registrator \
+	&& export GOPATH=/go \
+	&& git config --global http.https://gopkg.in.followRedirects true \
+	&& dep ensure \
 	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator


### PR DESCRIPTION
A quick fix to make `Dockerfile.dev` usable and more or less match `Dockerfile`.

Also, fixes a whitespace formatting issue in `Dockerfile`