### PR TITLE
Add support for Consul gRPC check

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -115,10 +115,21 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}
+	} else if grpc := service.Attrs["check_grpc"]; grpc != "" {
+		check.GRPC = fmt.Sprintf("%s:%d", service.IP, service.Port)
+		if timeout := service.Attrs["check_timeout"]; timeout != "" {
+			check.Timeout = timeout
+		}
+		if useTLS := service.Attrs["check_grpc_use_tls"]; useTLS != "" {
+			check.GRPCUseTLS = true
+			if tlsSkipVerify := service.Attrs["check_tls_skip_verify"]; tlsSkipVerify != "" {
+				check.TLSSkipVerify = true
+			}
+		}
 	} else {
 		return nil
 	}
-	if check.Script != "" || check.HTTP != "" || check.TCP != "" {
+	if check.Script != "" || check.HTTP != "" || check.TCP != "" || check.GRPC != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -93,6 +93,20 @@ healthy.
 SERVICE_CHECK_TTL=30s
 ```
 
+### Consul gRPC Check
+
+This feature is only available when using Consul 1.0.5 or newer. Containers
+specifying these extra metadata in labels or environment will be used to
+register an gRPC health check with the service.
+
+```bash
+SERVICE_CHECK_GRPC=true
+SERVICE_CHECK_INTERVAL=5s
+SERVICE_CHECK_TIMEOUT=3s              # optional, Consul default uses 10s
+SERVICE_CHECK_GRPC_USE_TLS=true       # optional, Consul default uses false
+SERVICE_CHECK_TLS_SKIP_VERIFY=true    # optional, Consul default uses false
+```
+
 ### Consul Initial Health Check Status
 
 By default when a service is registered against Consul, the state is set to "critical". You can specify the initial health check status.


### PR DESCRIPTION
This add support for Consul gRPC check which was first introduced with Consul 1.0.5 release. The backends doc is also updated.