### PR TITLE
Extended SkyDNS2 registration

### DIFF
--- a/skydns2/skydns2.go
+++ b/skydns2/skydns2.go
@@ -70,7 +70,9 @@ func (r *Skydns2Adapter) Services() ([]*bridge.Service, error) {
 }
 
 func (r *Skydns2Adapter) servicePath(service *bridge.Service) string {
-	return r.path + "/" + service.Name + "/" + service.ID
+	longContainerId := service.Origin.ContainerID
+	shortContainerId := longContainerId[0:13]
+	return r.path + "/" + service.Name + "/" + service.ID + "/" + shortContainerId
 }
 
 func domainPath(domain string) string {


### PR DESCRIPTION
I've added the (short) docker container ID to the SkyDNS2 registration to allow for multiple containers with the same name and service id.

I faced the issue where, when registering scaled services with the same service name (say; exampleimage) and service id (say: acceptance) would result in only one registration that had been overwritten because of the same service path.

By means of this pull request I've added the container id to the service path to differentiate between these scaled containers and allow the SkyDNS resolving to work correctly. Since SkyDNS uses wildcard resolving (see: https://github.com/skynetservices/skydns#wildcards) this pull request won't change behaviour and all examples still remain valid. It does fix the before mentioned bug however and caters for scaling containers using the same image + service label combination, a pattern commonly see in AWS ECS.

Example:
Before the pull request:
2 images with same name + service id would result in the following **single** SkyDNS registration:
```
etcdctl ls /skydns/local/skydns/example-image-8080/acceptance
/skydns/local/skydns/example-image-8080/acceptance
```

After the pull request change:
2 images with same name + service id would result in the following **multiple** SkyDNS registrations:
```
etcdctl ls /skydns/local/skydns/example-image-8080/acceptance
/skydns/local/skydns/example-image-8080/acceptance/106c51e5924b9
/skydns/local/skydns/example-image-8080/acceptance/8ac9281d89f5e
```