### PR TITLE
Feature/consul http method

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -99,10 +99,16 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
 		}
+		if method := service.Attrs["check_http_method"]; method != "" {
+			check.Method = method
+		}
 	} else if path := service.Attrs["check_https"]; path != "" {
 		check.HTTP = fmt.Sprintf("https://%s:%d%s", service.IP, service.Port, path)
 		if timeout := service.Attrs["check_timeout"]; timeout != "" {
 			check.Timeout = timeout
+		}
+		if method := service.Attrs["check_https_method"]; method != "" {
+			check.Method = method
 		}
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
 		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -36,7 +36,7 @@ register an HTTP health check with the service.
 SERVICE_80_CHECK_HTTP=/health/endpoint/path
 SERVICE_80_CHECK_INTERVAL=15s
 SERVICE_80_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
-SERVICE_80_CHECK_METHOD=HEAD		# optional, Consul default used otherwise
+SERVICE_80_CHECK_HTTP_METHOD=HEAD	# optional, Consul default used otherwise
 ```
 
 It works for services on any port, not just 80. If its the only service,
@@ -52,7 +52,7 @@ register an HTTPS health check with the service.
 SERVICE_443_CHECK_HTTPS=/health/endpoint/path
 SERVICE_443_CHECK_INTERVAL=15s
 SERVICE_443_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
-SERVICE_443_CHECK_METHOD=HEAD		# optional, Consul default used otherwise
+SERVICE_443_CHECK_HTTPS_METHOD=HEAD	# optional, Consul default used otherwise
 ```
 
 ### Consul TCP Check

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -36,6 +36,7 @@ register an HTTP health check with the service.
 SERVICE_80_CHECK_HTTP=/health/endpoint/path
 SERVICE_80_CHECK_INTERVAL=15s
 SERVICE_80_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
+SERVICE_80_CHECK_METHOD=HEAD		# optional, Consul default used otherwise
 ```
 
 It works for services on any port, not just 80. If its the only service,
@@ -51,6 +52,7 @@ register an HTTPS health check with the service.
 SERVICE_443_CHECK_HTTPS=/health/endpoint/path
 SERVICE_443_CHECK_INTERVAL=15s
 SERVICE_443_CHECK_TIMEOUT=1s		# optional, Consul default used otherwise
+SERVICE_443_CHECK_METHOD=HEAD		# optional, Consul default used otherwise
 ```
 
 ### Consul TCP Check


### PR DESCRIPTION
Adds support for specifying HTTP method with Consul HTTP checks by way of `SERVICE_*_CHECK_HTTP_METHOD` and `SERVICE_*_CHECK_HTTPS_METHOD` variables. This addresses issue #579.

Tested with a `docker-compose.yml`:
```
testservice:
  build: .
  ports:
    - '59017:80'
  environment:
    - SERVICE_NAME=testservice
    - SERVICE_80_CHECK_HTTP=/status
    - SERVICE_80_CHECK_HTTP_METHOD=HEAD
    - SERVICE_80_CHECK_TIMEOUT=1s
    - SERVICE_80_CHECK_INTERVAL=10s
```
Consul output:
```
$ curl http://localhost:8500/v1/health/checks/testservice
[
    {
        "Node": "dtm-laptop",
        "CheckID": "service:dtm-laptop:testservice_testservice_1:80",
        "Name": "Service 'testservice' check",
        "Status": "passing",
        "Notes": "",
        "Output": "HTTP HEAD http://127.0.0.1:59017/status: 200 OK Output: ",
        "ServiceID": "dtm-laptop:testservice_testservice_1:80",
        "ServiceName": "testservice",
        "ServiceTags": [],
        "Definition": {},
        "CreateIndex": 11,
        "ModifyIndex": 12
    }
]
```