### PR TITLE
resolve merge conflicts in PR-568 (update vendor libraries to fix tls support)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2
 jobs:
   build:
-    machine: true
+    docker:
+      - image: gliderlabs/ci:build-2
+        command: ["/bin/bash"]
+    working_directory: /go/src/github.com/gliderlabs/registrator
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           command: make circleci
       - run:
@@ -14,14 +18,12 @@ jobs:
       - deploy:
           name: Deploy website
           command: |
-            if [[ "$CIRCLE_BRANCH" == "master" ]]; then
-              mv .dockerignore .dockerignore-repo
-              docker run -v /home/circleci/.ssh:/tmp/ssh -v $PWD:/work -e MASTER=$MASTER -e TAG=$TAG gliderlabs/pagebuilder deploy "build $CIRCLE_BUILD_NUM"
-              mv .dockerignore-repo .dockerignore
+            if is-branch "master"; then
+              eval $(docker run gliderlabs/pagebuilder circleci-cmd)
             fi
       - deploy:
           name: Deploy beta channel
           command: |
-            if [[ "$CIRCLE_BRANCH" == "release" ]]; then
+            if is-branch "release"; then
               make release
             fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
-release
-build
 .git
+.gvm_local
+build
+release
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-release
+.gvm_local
 build
+release
 vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM alpine:3.7 AS builder
-COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk --no-cache add -t build-deps build-base go git curl \
-	&& apk --no-cache add ca-certificates \
-	&& export GOPATH=/go && mkdir -p /go/bin && export PATH=$PATH:/go/bin \
+FROM golang:1.9.4-alpine3.7 AS builder
+WORKDIR /go/src/github.com/gliderlabs/registrator/
+COPY . .
+RUN \
+	apk add --no-cache curl git \
 	&& curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh \
-	&& cd /go/src/github.com/gliderlabs/registrator \
-	&& export GOPATH=/go \
-	&& git config --global http.https://gopkg.in.followRedirects true \
-	&& dep ensure \
-	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
-	&& rm -rf /go \
-	&& apk del --purge build-deps
+	&& dep ensure -vendor-only \
+	&& CGO_ENABLED=0 GOOS=linux go build \
+		-a -installsuffix cgo \
+		-ldflags "-X main.Version=$(cat VERSION)" \
+		-o bin/registrator \
+		.
 
 FROM alpine:3.7
-COPY --from=builder /bin/registrator /bin/registrator
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/src/github.com/gliderlabs/registrator/bin/registrator /bin/registrator
+
 ENTRYPOINT ["/bin/registrator"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,50 +3,65 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:6da51e5ec493ad2b44cb04129e2d0a068c8fb9bd6cb5739d199573558696bb94"
   name = "github.com/Azure/go-ansiterm"
   packages = [
     ".",
-    "winterm"
+    "winterm",
   ]
+  pruneopts = "UT"
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
+  digest = "1:bf42be3cb1519bf8018dfd99720b1005ee028d947124cab3ccf965da59381df6"
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7da180ee92d8bd8bb8c37fc560e673e6557c392f"
   version = "v0.4.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:3721a10686511b80c052323423f0de17a8c06d417dbdd3b392b1578432a33aae"
   name = "github.com/Nvveen/Gotty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
+  digest = "1:2209584c0f7c9b68c23374e659357ab546e1b70eec2761f03280f69a8fd23d77"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
   version = "v2.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:fc8dbcc2a5de7c093e167828ebbdf551641761d2ad75431d3a167d467a264115"
   name = "github.com/containerd/continuity"
   packages = ["pathdriver"]
+  pruneopts = "UT"
   revision = "c6cef34830231743494fe2969284df7b82cc0ad0"
 
 [[projects]]
+  digest = "1:b61d4e32d5101ba4056bce8ff33831ab40884ff13fabc1d2e2a3d67648e0fdcb"
   name = "github.com/coreos/go-etcd"
   packages = ["etcd"]
+  pruneopts = "UT"
   revision = "f02171fbd43c7b9b53ce8679b03235a1ef3c7b12"
   version = "v2.0.0"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:49a2a779b1af8f02547b5a505eb1382f9d42299ec7215f34a32535e6af9a1c9e"
   name = "github.com/docker/docker"
   packages = [
     "api/types",
@@ -73,142 +88,184 @@
     "pkg/stdcopy",
     "pkg/system",
     "pkg/term",
-    "pkg/term/windows"
+    "pkg/term/windows",
   ]
+  pruneopts = "UT"
   revision = "a422774e593b33bd287d9890544ad9e09b380d8c"
 
 [[projects]]
+  digest = "1:87dcb59127512b84097086504c16595cf8fef35b9e0bfca565dfc06e198158d7"
   name = "github.com/docker/go-connections"
   packages = ["nat"]
+  pruneopts = "UT"
   revision = "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:6f82cacd0af5921e99bf3f46748705239b36489464f4529a1589bc895764fb18"
   name = "github.com/docker/go-units"
   packages = ["."]
+  pruneopts = "UT"
   revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
   version = "v0.3.3"
 
 [[projects]]
+  digest = "1:ef99b8925cb8a662a4cc98bb84cc3b431e45b8d8570957b9a2d053b467b9ec03"
   name = "github.com/fsouza/go-dockerclient"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ca33ff277b527ce11b793e62f9ba244129b01caf"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:54165f19429ccbd6d48f0ae7df3954b9485b166e6b163c028529892a5a87fabf"
   name = "github.com/gliderlabs/pkg"
   packages = ["usage"]
+  pruneopts = "UT"
   revision = "36f28d47ec7aae4d25d3d2741ac5af91f7f18680"
 
 [[projects]]
+  digest = "1:9a688317f3231e0175b3429033f44411906c0ce119361b7b5019d01375f8cff7"
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:7d9085638f210faa86720b5fe8c4cd9303edb853ed93929852a4384a4e6c956f"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
+  pruneopts = "UT"
   revision = "fb848fc48818f58690db09d14640513aa6bf3c02"
   version = "v1.0.7"
 
 [[projects]]
   branch = "master"
+  digest = "1:77cb3be9b21ba7f1a4701e870c84ea8b66e7d74c7c8951c58155fdadae9414ec"
   name = "github.com/hashicorp/go-cleanhttp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d5fe4b57a186c716b0e00b8c301cbd9b4182694d"
 
 [[projects]]
   branch = "master"
+  digest = "1:45aad874d3c7d5e8610427c81870fb54970b981692930ec2a319ce4cb89d7a00"
   name = "github.com/hashicorp/go-rootcerts"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6bb64b370b90e7ef1fa532be9e591a81c3493e00"
 
 [[projects]]
+  digest = "1:0dd7b7b01769f9df356dc99f9e4144bdbabf6c79041ea7c0892379c5737f3c44"
   name = "github.com/hashicorp/serf"
   packages = ["coordinate"]
+  pruneopts = "UT"
   revision = "d6574a5bb1226678d7010325fb6c985db20ee458"
   version = "v0.8.1"
 
 [[projects]]
+  digest = "1:39404cfbb35df632e9225831977e498395916ff8b20bec1aca98b4daace26e22"
   name = "github.com/miekg/dns"
   packages = ["."]
+  pruneopts = "UT"
   revision = "83c435cc65d2862736428b9b4d07d0ab10ad3e4d"
   version = "v1.0.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:12ae6210bdbdad658a9a67fd95cd9c99f7fdbf12f6d36eaf0af704e69dacf4f5"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
 
 [[projects]]
+  digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
+  pruneopts = "UT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
+  digest = "1:11db38d694c130c800d0aefb502fb02519e514dc53d9804ce51d1ad25ec27db6"
   name = "github.com/opencontainers/image-spec"
   packages = [
     "specs-go",
-    "specs-go/v1"
+    "specs-go/v1",
   ]
+  pruneopts = "UT"
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:1869683e323ebff2bdf8adcb560f82bf6f8d94019d35099e3403f7df12e9c07e"
   name = "github.com/opencontainers/runc"
   packages = [
     "libcontainer/system",
-    "libcontainer/user"
+    "libcontainer/user",
   ]
+  pruneopts = "UT"
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:4d92d3bcd412de705100c10f0428a0b63b12f3d12455ebae46e9ea384c23b333"
   name = "github.com/samuel/go-zookeeper"
   packages = ["zk"]
+  pruneopts = "UT"
   revision = "c4fab1ac1bec58281ad0667dc3f0907a9476ac47"
 
 [[projects]]
+  digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:f85e109eda8f6080877185d1c39e98dd8795e1780c08beca28304b87fd855a1c"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "UT"
   revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:0faa1e97cfa78445bc4d20d70b40929e88040c8f3110eb497f965d41bb6e593a"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
     "ed25519/internal/edwards25519",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = "UT"
   revision = "e73bf333ef8920dbb52ad18d4bd38ad9d9bc76d7"
 
 [[projects]]
   branch = "master"
+  digest = "1:ebe951b4df51f83f0de0847319bb022f9c96a4649f1cf18a90aa4893ef2b82fd"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -217,28 +274,43 @@
     "internal/iana",
     "internal/socket",
     "ipv4",
-    "ipv6"
+    "ipv6",
   ]
+  pruneopts = "UT"
   revision = "5f9ae10d9af5b1c89ae6904293b14b064d4ada23"
 
 [[projects]]
   branch = "master"
+  digest = "1:6372ba5b1cf771e7774ee197d79827fea93a995e46b6c49e1bbfdce6ab46f77d"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "79b0c6888797020a994db17c8510466c72fe75d9"
 
 [[projects]]
+  digest = "1:77b931135abb2ac4c127e7843d1231af0977227aafa21d9bb8c79b74644dcc39"
   name = "gopkg.in/coreos/go-etcd.v0"
   packages = ["etcd"]
+  pruneopts = "UT"
   revision = "6aa2da5a7a905609c93036b9307185a04a5a84a5"
   version = "v0.4.6"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cda685c394db30d7f3d3c76aa470320ba13d83a37c6c53fec0e58dd0566321f4"
+  input-imports = [
+    "github.com/cenkalti/backoff",
+    "github.com/coreos/go-etcd/etcd",
+    "github.com/fsouza/go-dockerclient",
+    "github.com/gliderlabs/pkg/usage",
+    "github.com/hashicorp/consul/api",
+    "github.com/hashicorp/go-cleanhttp",
+    "github.com/samuel/go-zookeeper/zk",
+    "github.com/stretchr/testify/assert",
+    "gopkg.in/coreos/go-etcd.v0/etcd",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,22 +1,8 @@
+# constraints
+
 [[constraint]]
   name = "github.com/cenkalti/backoff"
   version = "2.0.0"
-
-[[constraint]]
-  name = "github.com/coreos/go-etcd"
-  version = "2.0.0"
-
-[[constraint]]
-  name = "github.com/fsouza/go-dockerclient"
-  version = "1.2.0"
-
-[[override]]
-  name = "github.com/docker/docker"
-  revision = "a422774e593b33bd287d9890544ad9e09b380d8c"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/gliderlabs/pkg"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"
@@ -27,16 +13,40 @@
   name = "github.com/hashicorp/go-cleanhttp"
 
 [[constraint]]
+  name = "github.com/fsouza/go-dockerclient"
+  version = "1.2.0"
+
+[[constraint]]
+  name = "github.com/coreos/go-etcd"
+  version = "2.0.0"
+
+[[constraint]]
+  name = "gopkg.in/coreos/go-etcd.v0"
+  version = "0.4.6"
+
+[[constraint]]
   branch = "master"
   name = "github.com/samuel/go-zookeeper"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/gliderlabs/pkg"
 
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.2.1"
 
-[[constraint]]
-  name = "gopkg.in/coreos/go-etcd.v0"
-  version = "0.4.6"
+# overrides
+
+[[override]]
+  name = "github.com/docker/docker"
+  revision = "a422774e593b33bd287d9890544ad9e09b380d8c"
+
+[[override]]
+  branch = "master"
+  name = "github.com/Azure/go-ansiterm"
+
+# prune
 
 [prune]
   go-tests = true

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -38,8 +38,8 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 		tlsConfigDesc := &consulapi.TLSConfig{
 			Address:            uri.Host,
 			CAFile:             os.Getenv("CONSUL_CACERT"),
-			CertFile:           os.Getenv("CONSUL_TLSCERT"),
-			KeyFile:            os.Getenv("CONSUL_TLSKEY"),
+			CertFile:           os.Getenv("CONSUL_CLIENT_CERT"),
+			KeyFile:            os.Getenv("CONSUL_CLIENT_KEY"),
 			InsecureSkipVerify: false,
 		}
 		tlsConfig, err := consulapi.SetupTLSConfig(tlsConfigDesc)
@@ -49,7 +49,7 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 		config.Scheme = "https"
 		transport := cleanhttp.DefaultPooledTransport()
 		transport.TLSClientConfig = tlsConfig
-		config.HttpClient.Transport = transport
+		config.Transport = transport
 		config.Address = uri.Host
 	} else if uri.Host != "" {
 		config.Address = uri.Host

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -21,8 +21,8 @@ Consul supports tags but no arbitrary service attributes.
 
 When using the `consul-tls` scheme, registrator communicates with Consul through TLS. You must set the following environment variables:
  * `CONSUL_CACERT` : CA file location
- * `CONSUL_TLSCERT` : Certificate file location
- * `CONSUL_TLSKEY` : Key location
+ * `CONSUL_CLIENT_CERT` : Certificate file location
+ * `CONSUL_CLIENT_KEY` : Key location
 
 For more information on the Consul check parameters below, see the [API documentation](https://www.consul.io/api/agent/check.html#register-check).
 


### PR DESCRIPTION
This PR resolves the merge conflicts in #568 

Package dependencies that were out of date or old, due to the age of the PR, were removed or replaced in favor of dependencies from master. The dependencies file was also sorted to make maintaining it easier.

I also fixed the unintentional addition of the `vendor/` directory to the branch. This should not be committed to source control, instead allowing `dep ensure -vendor-only` to populate it during a build.

The multi stage build was also revised to properly lock it to a consistent go version (in this case, 1.9.4, which was the default package version for golang at alpine3.7).

Follow-up PRs may wish to further bump the golang version / other packages. This PR is purely to resolve the merge conflicts to allow us to get a build.