### PR TITLE
Feature #630 basic service mesh support for Consul

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -134,12 +134,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7d9085638f210faa86720b5fe8c4cd9303edb853ed93929852a4384a4e6c956f"
+  digest = "1:8b20ed6a6df0628913a69e4c1709537b2e26c7be4aca856bf52b431cf1ce6d90"
   name = "github.com/hashicorp/consul"
   packages = ["api"]
   pruneopts = "UT"
-  revision = "fb848fc48818f58690db09d14640513aa6bf3c02"
-  version = "v1.0.7"
+  revision = "a82e6a7fd33a0d05b9b871bcaf1d7595c9b8dedc"
+  version = "v1.5.2"
 
 [[projects]]
   branch = "master"
@@ -180,6 +180,14 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+
+[projects]]
+  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
+  version = "v1.1.2"
 
 [[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,7 +6,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/consul"
-  version = "1.0.7"
+  version = "1.5.1"
 
 [[constraint]]
   branch = "master"

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -346,9 +346,17 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		service.ID = id
 	}
 
+	mesh := mapDefault(metadata, "mesh", "")
+	if mesh != "" {
+		service.Mesh, _ = strconv.ParseBool(mesh)
+	} else {
+		service.Mesh = b.config.ServiceMesh
+	}
+
 	delete(metadata, "id")
 	delete(metadata, "tags")
 	delete(metadata, "name")
+	delete(metadata, "mesh")
 	service.Attrs = metadata
 	service.TTL = b.config.RefreshTtl
 

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -29,6 +29,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+	ServiceMesh     bool
 }
 
 type Service struct {
@@ -39,6 +40,7 @@ type Service struct {
 	Tags  []string
 	Attrs map[string]string
 	TTL   int
+	Mesh  bool
 
 	Origin ServicePort
 }

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -86,6 +86,11 @@ func (r *ConsulAdapter) Register(service *bridge.Service) error {
 	registration.Address = service.IP
 	registration.Check = r.buildCheck(service)
 	registration.Meta = service.Attrs
+	if service.Mesh == true {
+		registration.Connect = &consulapi.AgentServiceConnect{
+			SidecarService: &consulapi.AgentServiceRegistration{},
+		}
+	}
 	return r.client.Agent().ServiceRegister(registration)
 }
 

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -110,6 +110,24 @@ If enabled this should be much longer than any expected recoverable outage.
 SERVICE_CHECK_DEREGISTER_AFTER=10m
 ```
 
+### Consul ServiceMesh Support
+
+Consul can support ServiceMesh by integrating with proxies like Envoy, the most convenient way to enable this capability is creating a Service like [this](https://www.consul.io/docs/connect/registration/sidecar-service.html#minimal-example):
+
+```json
+{
+  "service": {
+    "name": "web",
+    "port": 8080,
+    "connect": { "sidecar_service": {} }
+  }
+}
+```
+
+Then Consul will automatically generate a corresponding SidecarService with default configurations.
+
+In Registrator, you may add the `"connect": { "sidecar_service": {} }` configuration by the `-service-mesh` flag. It's also overridable by `SERVICE_MESH`.
+
 ## Consul KV
 
 	consulkv://<address>:<port>/<prefix>

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,6 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
+`-service-mesh`                  |       | Enable basic ServiceMesh support in Consul
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.

--- a/docs/user/services.md
+++ b/docs/user/services.md
@@ -16,11 +16,12 @@ object into a particular registry.
 		Port  int                  // port service is listening on
 		Tags  []string             // extra tags to classify service
 		Attrs map[string]string    // extra attribute metadata
+		Mesh  bool                 // Enable basic ServiceMesh support in Consul
 	}
 
 ## Container Overrides
 
-The fields `Name`, `Tags`, `Attrs`, and `ID` can be overridden by user-defined
+The fields `Name`, `Tags`, `Attrs`, `Mesh` and `ID` can be overridden by user-defined
 container metadata. You can use environment variables or labels prefixed with
 `SERVICE_` or `SERVICE_x_` to set values, where `x` is the internal exposed port.
 For example `SERVICE_NAME=customerdb` and `SERVICE_80_NAME=api`.

--- a/registrator.go
+++ b/registrator.go
@@ -31,7 +31,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
-var serviceMesh = flag.Bool("service-mesh", false, "Enable basic ServiceMesh support (for Consul)")
+var serviceMesh = flag.Bool("service-mesh", false, "Enable basic ServiceMesh support (for Consul only)")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {

--- a/registrator.go
+++ b/registrator.go
@@ -31,6 +31,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var serviceMesh = flag.Bool("service-mesh", false, "Enable basic ServiceMesh support (for Consul)")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -112,6 +113,7 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
+		ServiceMesh:     *serviceMesh,
 	})
 
 	assert(err)


### PR DESCRIPTION
This PR is trying to implement #630.

### Consul ServiceMesh Support

Consul can support ServiceMesh by integrating with proxies like Envoy, the most convenient way to enable this capability is creating a Service like [this](https://www.consul.io/docs/connect/registration/sidecar-service.html#minimal-example):

 ```json
{
  "service": {
    "name": "web",
    "port": 8080,
    "connect": { "sidecar_service": {} }
  }
}
```

Then Consul will automatically generate a corresponding SidecarService with default configurations.

In Registrator, you may add the `"connect": { "sidecar_service": {} }` configuration by the `-service-mesh` flag. It's also overridable by `SERVICE_MESH`.

Your feedbacks are appreciated. 
