### PR TITLE
Handle SERVICE_<port>_<type>_<metadata> encodings

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -266,7 +266,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		port.HostIP = b.config.HostIp
 	}
 
-	metadata, metadataFromPort := serviceMetaData(container.Config, port.ExposedPort)
+	metadata, metadataFromPort := serviceMetaData(container.Config, port)
 
 	ignore := mapDefault(metadata, "ignore", "")
 	if ignore != "" {


### PR DESCRIPTION
At present SERVICE_<port>_<metadata> detection fails to account for the
port type, which prevents selective filtering - e.g. of specific TCP or UDP ports
for individual services.

We can fix this up by scanning for a port type designation and comparing this
against the service port's type definition before determining how to proceed.

With this in place, we can now use any of:

SERVICE_xxx_TCP_IGNORE
SERVICE_xxx_TCP_NAME
SERVICE_xxx_UDP_IGNORE
SERVICE_xxx_UDP_NAME
...

for manipulating port-specific service metadata.

This should address issue #244 