### PR TITLE
Convert from check.Script to check.Args for Consul API changes

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -105,9 +105,9 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 			check.Timeout = timeout
 		}
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
-		check.Script = fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd)
+		check.Args = []string{"check-cmd", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd}
 	} else if script := service.Attrs["check_script"]; script != "" {
-		check.Script = r.interpolateService(script, service)
+		check.Args = []string{r.interpolateService(script, service)}
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
@@ -118,7 +118,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else {
 		return nil
 	}
-	if check.Script != "" || check.HTTP != "" || check.TCP != "" {
+	if len(check.Args) != 0 || check.HTTP != "" || check.TCP != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {


### PR DESCRIPTION
In upstream Consul (as of May 2018), check.Script has been removed in
favour of check.Args, which now results in the following build error:

consul/consul.go:108:8: check.Script undefined (type *api.AgentServiceCheck has no field or method Script)
consul/consul.go:110:8: check.Script undefined (type *api.AgentServiceCheck has no field or method Script)
consul/consul.go:121:10: check.Script undefined (type *api.AgentServiceCheck has no field or method Script)

Update to use the new convention.