### PR TITLE
fix: Convert from check.Script to check.Args for Consul API changes

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -111,9 +111,9 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 			check.Method = method
 		}
 	} else if cmd := service.Attrs["check_cmd"]; cmd != "" {
-		check.Args = []string{"check-cmd", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd}
+		check.Args = strings.Split(fmt.Sprintf("check-cmd %s %s %s", service.Origin.ContainerID[:12], service.Origin.ExposedPort, cmd), " ")
 	} else if script := service.Attrs["check_script"]; script != "" {
-		check.Args = []string{r.interpolateService(script, service)}
+		check.Args = strings.Split(r.interpolateService(script, service), " ")
 	} else if ttl := service.Attrs["check_ttl"]; ttl != "" {
 		check.TTL = ttl
 	} else if tcp := service.Attrs["check_tcp"]; tcp != "" {
@@ -124,7 +124,7 @@ func (r *ConsulAdapter) buildCheck(service *bridge.Service) *consulapi.AgentServ
 	} else {
 		return nil
 	}
-	if len(check.Args) != 0 || check.HTTP != "" || check.TCP != "" {
+	if len(check.Args) > 0 || check.HTTP != "" || check.TCP != "" {
 		if interval := service.Attrs["check_interval"]; interval != "" {
 			check.Interval = interval
 		} else {


### PR DESCRIPTION
This PR incorporates the changes from GH-643

"Consul 1.0.7 was the last version to support the string Script API, which had been long deprecated. 1.1.0 and later use []string Args. This PR updates Consul support to this new property."

I have compiled and tested and can confirm the Registrator `SERVICE_*_CHECK_SCRIPT` environment param works with Consol 1.6.1 with the below changes.

credit to @jhsolor