### PR TITLE
Add reference to -explicit

### DIFF
--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -35,6 +35,7 @@ Option                           | Since | Description
 ------                           | ----- | -----------
 `-cleanup`                       | v7    | Cleanup dangling services
 `-deregister <mode>`             | v6    | Deregister exited services "always" or "on-success". Default: always
+`-explicit`                      |       | Only register containers which have SERVICE_NAME label set
 `-internal`                      |       | Use exposed ports instead of published ports
 `-ip <ip address>`               |       | Force IP address used for registering services
 `-resync <seconds>`              | v6    | Frequency all services are resynchronized. Default: 0, never


### PR DESCRIPTION
The `-explicit` argument was added in 82dc4fd9fa4166cb759d9dbe3c43f8fec93c4c75, but not reflected in the docs.