### PR TITLE
Use ip from env

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -317,6 +317,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 
 	// NetworkMode can point to another container (kuberenetes pods)
+	var ipFromNetworkContainer string
 	networkMode := container.HostConfig.NetworkMode
 	if networkMode != "" {
 		if strings.HasPrefix(networkMode, "container:") {
@@ -326,9 +327,34 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 			if err != nil {
 				log.Println("unable to inspect network container:", networkContainerId[:12], err)
 			} else {
-				service.IP = networkContainer.NetworkSettings.IPAddress
-				log.Println(service.Name + ": using network container IP " + service.IP)
+				ipFromNetworkContainer = networkContainer.NetworkSettings.IPAddress
+
+				if ipFromNetworkContainer != "" {
+					service.IP = networkContainer.NetworkSettings.IPAddress
+					log.Println(service.Name + ": using network container IP " + service.IP)
+				} else {
+					log.Println(service.Name + ": network container IP address is empty")
+				}
 			}
+		}
+	}
+
+	// Grab the container IP address from docker or kubernetes env
+	log.Println("Fetch ip using "+ b.config.UseIpFromEnv  + " :" + ipFromNetworkContainer+ "'")
+	if b.config.UseIpFromEnv != "" && ipFromNetworkContainer == "" {
+		log.Println("Going to reset the ip using "+b.config.UseIpFromEnv  + "'")
+		var isIpFound bool = false
+		for _, requiredEnv := range container.Config.Env {
+			if strings.Contains(requiredEnv, b.config.UseIpFromEnv) {
+				service.IP = requiredEnv[len(b.config.UseIpFromEnv)+1:]
+				log.Println(service.Name + ": using container IP '" + service.IP + "' from env '" + b.config.UseIpFromEnv  + "'")
+				isIpFound = true
+				break
+			}
+		}
+		if isIpFound == false {
+			log.Println(service.Name + ": could not found env '" + b.config.UseIpFromEnv  +
+				"' from docker env")
 		}
 	}
 

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -24,6 +24,7 @@ type Config struct {
 	Internal        bool
 	Explicit        bool
 	UseIpFromLabel  string
+	UseIpFromEnv    string
 	ForceTags       string
 	RefreshTtl      int
 	RefreshInterval int

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,6 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
+`-useIpFromEnv <env>`        	 |       | Uses the IP address from the given environment variable, which is assigned to a container, for registration with Consul
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.

--- a/registrator.go
+++ b/registrator.go
@@ -23,6 +23,7 @@ var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
+var useIpFromEnv = flag.String("useIpFromEnv", "", "Use IP from the container environment variable")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
 var forceTags = flag.String("tags", "", "Append tags for all registered services")
@@ -107,6 +108,7 @@ func main() {
 		Internal:        *internal,
 		Explicit:        *explicit,
 		UseIpFromLabel:  *useIpFromLabel,
+		UseIpFromEnv:    *useIpFromEnv,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,

--- a/registrator.iml
+++ b/registrator.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
Extending the support to pull request https://github.com/gliderlabs/registrator/pull/544 
The Registrator will register services to backend using run-time IPs provided by Kubernetes. Since EKS will use a non-bridge approach i.e. preallocating IPs on Worker-Nodes, we need to have a way to pass dynamic IPs to Registrator. 
In Kubernetes, we can use downward status APIs to get POD ips at run time, and we can assign an environment variable to them. 

Example: 
```
          - name: POD_IP
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: status.podIP
```
With this in mind, we can run registrator like a daemon set, while consul-client is also running as daemonset in Kubernetes. 
```
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  creationTimestamp: null
  labels:
    run: registrator
  name: registrator
spec:
  selector:
    matchLabels:
      run: registrator
  template:
    metadata:
      creationTimestamp: null
      labels:
        run: registrator
        app: registrator
        service: consul-registrator
        department: cloudops
    spec:
      hostNetwork: true
      containers:
      - image: artifactory.arlocloud.com/docker-local/registrator:v4
        name: registrator
        command: ["/bin/sh"]
        args: ["-c", "registrator -useIpFromEnv=POD_IP -explicit=true -resync=60  -cleanup -deregister=always consul://${NODE_IP}:8500"]
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: NODE_IP
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        volumeMounts:
        - mountPath: /tmp/docker.sock
          name: docker-sock
      volumes:
      - name: docker-sock
        hostPath:
          path: /var/run/docker.sock
```

Now deployment spec can be changed to below to provide auto-registration:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx0-deployment
  labels:
    app: nginx0-deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: nginx0
  template:
    metadata:
      labels:
        app: nginx0
    spec:
      containers:
      - name: nginx
        image: k8s.gcr.io/nginx:1.7.9
        ports:
        - containerPort: 80
        env:
        - name: NODE_NAME
          valueFrom:
            fieldRef:
              fieldPath: spec.nodeName
        - name: NODE_IP
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: POD_IP
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
        - name: NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        - name: SERVICE_80_NAME
          value: nginx
        - name: SERVICE_PORT
          value: "80"
        - name: SERVICE_TAGS
          value: "nginx,eu-west-1"
        resources:
          requests:
            memory: "250Mi"
            cpu: "500m"
          limits:
            memory: "250Mi"
            cpu: "500m"
```