### PR TITLE
-envFile option to read variables from within container at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Usage of /bin/registrator:
   -tags="": Append tags for all registered services
   -ttl=0: TTL for services (default is no expiry)
   -ttl-refresh=0: Frequency with which service TTLs are refreshed
+  -envFile="": Read envs from within container from specified file. Updates on each refresh
 ```
 
 ## Contributing

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -29,6 +29,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+	DynamicEnvFile  string
 }
 
 type Service struct {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -54,11 +54,20 @@ func combineTags(tagParts ...string) []string {
 	return tags
 }
 
-func serviceMetaData(config *dockerapi.Config, port string) (map[string]string, map[string]bool) {
-	meta := config.Env
+// serviceMetaData extracts metadata from Docker-container config.
+// meta - is highest priority metadata from other source
+func serviceMetaData(meta []string, config *dockerapi.Config, port string) (map[string]string, map[string]bool) {
+	if meta == nil {
+		meta = make([]string, 0)
+	}
+
+	for _, line := range config.Env {
+		meta = append(meta, line)
+	}
 	for k, v := range config.Labels {
 		meta = append(meta, k+"="+v)
 	}
+
 	metadata := make(map[string]string)
 	metadataFromPort := make(map[string]bool)
 	for _, kv := range meta {

--- a/consul/consul.go
+++ b/consul/consul.go
@@ -153,7 +153,10 @@ func (r *ConsulAdapter) Deregister(service *bridge.Service) error {
 }
 
 func (r *ConsulAdapter) Refresh(service *bridge.Service) error {
-	return nil
+	// It is safe for consul to update(re-register) service with same ID. ID is an unique identifier across whole Consul cluster.
+	// So if our service description changes we can update it in Consul as long as ID stay same.... 
+	// We never change service ID anyway.
+	return r.Register(service)
 }
 
 func (r *ConsulAdapter) Services() ([]*bridge.Service, error) {

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,6 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
+`-envFile <filepath>`            |       | Read envs from within container from specified file. Updates on each refresh
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.
@@ -63,6 +64,17 @@ containers and reregister all services.  This allows Registrator and the service
 registry to get back in sync if they fall out of sync. Use this option with caution
 as it will notify all the watches you may have registered on your services, and
 may rapidly flood your system (e.g. consul-template makes extensive use of watches).
+
+If the `-envFile` option is used, Registrator will try to extract specified file from **each** container. This file must be in simple env-file form:
+```
+SERVICE_DYNAMIC_META=metavalue
+SERVICE_NAME=dynamicname
+```
+
+It's contents will be used on first service initialization like any Label or ENV variable. Variables in file take highest priority over Label or ENV.
+If refreshInterval specified file will be rereaded on each refresh operation, so it is posiible to change Tags or Meta of registered service from inside container by application logic. It is even possible to change service name by specify diffrent `SERVICE_NAME` in file. 
+
+`-envFile` may not be supported by all backends, but Consul-catalog backend works well.
 
 ## Consul ACL token
 

--- a/registrator.go
+++ b/registrator.go
@@ -31,6 +31,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var dynamicEnvFile = flag.String("envFile", "", "Read envs from within container from specified file. Updates on each refresh")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -111,6 +112,7 @@ func main() {
 		RefreshTtl:      *refreshTtl,
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
+		DynamicEnvFile:  *dynamicEnvFile,
 		Cleanup:         *cleanup,
 	})
 


### PR DESCRIPTION
I need to change Consul service description from inside container by custom application logic. This patch allow this by specifying `-envFile` option to registrator which is the *file path inside containers*. Registrator try reads this file at runtime from each container instance and use as another source of configuration like Labels or ENV but with highest proprity.

**Examples**:
File /tmp/dynamic_envs inside test_container
```
SERVICE_NAME=my_new_service_name
SERVICE_TAGS=tag1,tag2
SERVICE_ANOTHER=custom_metadata_value
```
Registrator launch:
```
./registrator -ip 172.99.1.1 -cleanup -ttl 40 -ttl-refresh 10 -resync 60 -envFile /tmp/dynamic_envs consul://172.99.1.1:8500
```
Dynamic changes:
```
docker exec -it test_container /bin/sh -c "echo SERVICE_META=123 >> /tmp/dynamic_envs"
```

After refresh interval(10s) new metadata with name *meta* and value *123* appear in already registered consul service.