### PR TITLE
Flag is added to prevent publishing ip of the node, otherwise, traefi…

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -316,18 +316,21 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		}
 	}
 
+
 	// NetworkMode can point to another container (kuberenetes pods)
-	networkMode := container.HostConfig.NetworkMode
-	if networkMode != "" {
-		if strings.HasPrefix(networkMode, "container:") {
-			networkContainerId := strings.Split(networkMode, ":")[1]
-			log.Println(service.Name + ": detected container NetworkMode, linked to: " + networkContainerId[:12])
-			networkContainer, err := b.docker.InspectContainer(networkContainerId)
-			if err != nil {
-				log.Println("unable to inspect network container:", networkContainerId[:12], err)
-			} else {
-				service.IP = networkContainer.NetworkSettings.IPAddress
-				log.Println(service.Name + ": using network container IP " + service.IP)
+	if b.config.UseIpFromContainer == "" {
+		networkMode := container.HostConfig.NetworkMode
+		if networkMode != "" {
+			if strings.HasPrefix(networkMode, "container:") {
+				networkContainerId := strings.Split(networkMode, ":")[1]
+				log.Println(service.Name + ": detected container NetworkMode, linked to: " + networkContainerId[:12])
+				networkContainer, err := b.docker.InspectContainer(networkContainerId)
+				if err != nil {
+					log.Println("unable to inspect network container:", networkContainerId[:12], err)
+				} else {
+					service.IP = networkContainer.NetworkSettings.IPAddress
+					log.Println(service.Name + ": using network container IP " + service.IP)
+				}
 			}
 		}
 	}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -23,6 +23,7 @@ type Config struct {
 	HostIp          string
 	Internal        bool
 	Explicit        bool
+	UseIpFromContainer string
 	UseIpFromLabel  string
 	ForceTags       string
 	RefreshTtl      int

--- a/registrator.go
+++ b/registrator.go
@@ -22,6 +22,7 @@ var versionChecker = usage.NewChecker("registrator", Version)
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var explicit = flag.Bool("explicit", false, "Only register containers which have SERVICE_NAME label set")
+var useIpFromContainer = flag.String("ip-from-container", "", "Use IP of the container instead of node")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
 var refreshTtl = flag.Int("ttl", 0, "TTL for services (default is no expiry)")
@@ -106,6 +107,7 @@ func main() {
 		HostIp:          *hostIp,
 		Internal:        *internal,
 		Explicit:        *explicit,
+		UseIpFromContainer: *useIpFromContainer,
 		UseIpFromLabel:  *useIpFromLabel,
 		ForceTags:       *forceTags,
 		RefreshTtl:      *refreshTtl,


### PR DESCRIPTION
Traefik and other auto discovery systems registers same service twice because it appears twice with its own internal ip and ip of the node. In single node settings, it causes a problem.